### PR TITLE
fix: SSO redirect URLs dropping the port number

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	DataDir       string // Base directory for mutable data (uploads, db?)
 	MaxUploadSize int64  // Max size for file uploads in bytes
 	HashUploadDir string // Directory within DataDir to store hashlist uploads
+	ExternalURL   string // External URL for SSO redirects (e.g. https://krakenhashes.local:8443)
 }
 
 // NewConfig creates a new Config instance with values from environment variables
@@ -186,6 +187,7 @@ func NewConfig() *Config {
 		DataDir:       dataDir,
 		MaxUploadSize: maxUploadSize,
 		HashUploadDir: hashUploadDir,
+		ExternalURL:   os.Getenv("KH_EXTERNAL_URL"),
 	}
 }
 

--- a/backend/internal/handlers/auth/sso.go
+++ b/backend/internal/handlers/auth/sso.go
@@ -26,17 +26,19 @@ import (
 
 // SSOHandler handles SSO authentication requests
 type SSOHandler struct {
-	db         *db.DB
-	ssoManager *sso.Manager
-	ssoRepo    *repository.SSORepository
+	db          *db.DB
+	ssoManager  *sso.Manager
+	ssoRepo     *repository.SSORepository
+	externalURL string
 }
 
 // NewSSOHandler creates a new SSO handler
-func NewSSOHandler(database *db.DB, ssoManager *sso.Manager, ssoRepo *repository.SSORepository) *SSOHandler {
+func NewSSOHandler(database *db.DB, ssoManager *sso.Manager, ssoRepo *repository.SSORepository, externalURL string) *SSOHandler {
 	return &SSOHandler{
-		db:         database,
-		ssoManager: ssoManager,
-		ssoRepo:    ssoRepo,
+		db:          database,
+		ssoManager:  ssoManager,
+		ssoRepo:     ssoRepo,
+		externalURL: externalURL,
 	}
 }
 
@@ -139,11 +141,10 @@ func (h *SSOHandler) OAuthStart(w http.ResponseWriter, r *http.Request) {
 
 	// Get redirect URI from query params or use default
 	redirectURI := r.URL.Query().Get("redirect_uri")
-    if redirectURI == "" {
-        // Build default callback URL
-        redirectURI = getRequestBaseURL(r) + "/api/auth/oauth/" + providerIDStr + "/callback"
-    }
-
+	if redirectURI == "" {
+		// Build default callback URL
+		redirectURI = getRequestBaseURL(r, h.externalURL) + "/api/auth/oauth/" + providerIDStr + "/callback"
+	}
 
 	// Get authorization URL
 	authURL, err := h.ssoManager.GetStartURL(r.Context(), providerID, redirectURI)
@@ -219,10 +220,10 @@ func (h *SSOHandler) SAMLStart(w http.ResponseWriter, r *http.Request) {
 
 	// Get redirect URI from query params or use default
 	redirectURI := r.URL.Query().Get("redirect_uri")
-    if redirectURI == "" {
-        // Build default ACS URL
-        redirectURI = getRequestBaseURL(r) + "/api/auth/saml/" + providerIDStr + "/acs"
-    }
+	if redirectURI == "" {
+		// Build default ACS URL
+		redirectURI = getRequestBaseURL(r, h.externalURL) + "/api/auth/saml/" + providerIDStr + "/acs"
+	}
 
 	// Get authorization URL
 	authURL, err := h.ssoManager.GetStartURL(r.Context(), providerID, redirectURI)
@@ -326,7 +327,7 @@ func (h *SSOHandler) SAMLMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build ACS URL
-	acsURL := getRequestBaseURL(r) + "/api/auth/saml/" + providerIDStr + "/acs"
+	acsURL := getRequestBaseURL(r, h.externalURL) + "/api/auth/saml/" + providerIDStr + "/acs"
 
 	metadata, err := samlProvider.GenerateMetadata(acsURL)
 	if err != nil {
@@ -746,14 +747,14 @@ func (h *SSOHandler) logSSOLoginAttempt(r *http.Request, userID *uuid.UUID, prov
 
 // ssoRedirect redirects to frontend with optional message
 func (h *SSOHandler) ssoRedirect(w http.ResponseWriter, r *http.Request, path string) {
-    // Get the frontend URL from the origin or use default
-    origin := r.Header.Get("Origin")
-    if origin == "" {
-        origin = getRequestBaseURL(r)
-    }
+	// Get the frontend URL from the origin or use default
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		origin = getRequestBaseURL(r, h.externalURL)
+	}
 
-    redirectURL := origin + path
-    http.Redirect(w, r, redirectURL, http.StatusFound)
+	redirectURL := origin + path
+	http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
 // ssoErrorRedirect redirects to frontend with error message
@@ -761,24 +762,15 @@ func (h *SSOHandler) ssoErrorRedirect(w http.ResponseWriter, r *http.Request, er
 	h.ssoRedirect(w, r, "/login?sso_error="+url.QueryEscape(errorMsg))
 }
 
-// getRequestBaseURL adds request headers to preserve port 
-func getRequestBaseURL(r *http.Request) string {
-    scheme := r.Header.Get("X-Forwarded-Proto")
-    if scheme == "" {
-        scheme = r.Header.Get("X-Forwarded-Scheme")
-    }
-    if scheme == "" {
-        if r.TLS != nil {
-            scheme = "https"
-        } else {
-            scheme = "http"
-        }
-    }
-
-    host := r.Header.Get("X-Forwarded-Host")
-    if host == "" {
-        host = r.Host
-    }
-
-    return scheme + "://" + host
+// getRequestBaseURL gets config URL but falls back on default if missing
+func getRequestBaseURL(r *http.Request, externalURL string) string {
+	if externalURL != "" {
+		return externalURL
+	}
+	// Backward compatible fallback
+	scheme := "https"
+	if r.TLS == nil {
+		scheme = "http"
+	}
+	return scheme + "://" + r.Host
 }

--- a/backend/internal/handlers/auth/sso.go
+++ b/backend/internal/handlers/auth/sso.go
@@ -139,15 +139,11 @@ func (h *SSOHandler) OAuthStart(w http.ResponseWriter, r *http.Request) {
 
 	// Get redirect URI from query params or use default
 	redirectURI := r.URL.Query().Get("redirect_uri")
-	if redirectURI == "" {
-		// Build default callback URL
-		scheme := "https"
-		if r.TLS == nil {
-			scheme = "http"
-		}
-		host := r.Host
-		redirectURI = scheme + "://" + host + "/api/auth/oauth/" + providerIDStr + "/callback"
-	}
+    if redirectURI == "" {
+        // Build default callback URL
+        redirectURI = getRequestBaseURL(r) + "/api/auth/oauth/" + providerIDStr + "/callback"
+    }
+
 
 	// Get authorization URL
 	authURL, err := h.ssoManager.GetStartURL(r.Context(), providerID, redirectURI)
@@ -223,15 +219,10 @@ func (h *SSOHandler) SAMLStart(w http.ResponseWriter, r *http.Request) {
 
 	// Get redirect URI from query params or use default
 	redirectURI := r.URL.Query().Get("redirect_uri")
-	if redirectURI == "" {
-		// Build default ACS URL
-		scheme := "https"
-		if r.TLS == nil {
-			scheme = "http"
-		}
-		host := r.Host
-		redirectURI = scheme + "://" + host + "/api/auth/saml/" + providerIDStr + "/acs"
-	}
+    if redirectURI == "" {
+        // Build default ACS URL
+        redirectURI = getRequestBaseURL(r) + "/api/auth/saml/" + providerIDStr + "/acs"
+    }
 
 	// Get authorization URL
 	authURL, err := h.ssoManager.GetStartURL(r.Context(), providerID, redirectURI)
@@ -335,11 +326,7 @@ func (h *SSOHandler) SAMLMetadata(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build ACS URL
-	scheme := "https"
-	if r.TLS == nil {
-		scheme = "http"
-	}
-	acsURL := scheme + "://" + r.Host + "/api/auth/saml/" + providerIDStr + "/acs"
+	acsURL := getRequestBaseURL(r) + "/api/auth/saml/" + providerIDStr + "/acs"
 
 	metadata, err := samlProvider.GenerateMetadata(acsURL)
 	if err != nil {
@@ -759,22 +746,39 @@ func (h *SSOHandler) logSSOLoginAttempt(r *http.Request, userID *uuid.UUID, prov
 
 // ssoRedirect redirects to frontend with optional message
 func (h *SSOHandler) ssoRedirect(w http.ResponseWriter, r *http.Request, path string) {
-	// Get the frontend URL from the origin or use default
-	origin := r.Header.Get("Origin")
-	if origin == "" {
-		// Fall back to the request host
-		scheme := "https"
-		if r.TLS == nil {
-			scheme = "http"
-		}
-		origin = scheme + "://" + r.Host
-	}
+    // Get the frontend URL from the origin or use default
+    origin := r.Header.Get("Origin")
+    if origin == "" {
+        origin = getRequestBaseURL(r)
+    }
 
-	redirectURL := origin + path
-	http.Redirect(w, r, redirectURL, http.StatusFound)
+    redirectURL := origin + path
+    http.Redirect(w, r, redirectURL, http.StatusFound)
 }
 
 // ssoErrorRedirect redirects to frontend with error message
 func (h *SSOHandler) ssoErrorRedirect(w http.ResponseWriter, r *http.Request, errorMsg string) {
 	h.ssoRedirect(w, r, "/login?sso_error="+url.QueryEscape(errorMsg))
+}
+
+// getRequestBaseURL adds request headers to preserve port 
+func getRequestBaseURL(r *http.Request) string {
+    scheme := r.Header.Get("X-Forwarded-Proto")
+    if scheme == "" {
+        scheme = r.Header.Get("X-Forwarded-Scheme")
+    }
+    if scheme == "" {
+        if r.TLS != nil {
+            scheme = "https"
+        } else {
+            scheme = "http"
+        }
+    }
+
+    host := r.Header.Get("X-Forwarded-Host")
+    if host == "" {
+        host = r.Host
+    }
+
+    return scheme + "://" + host
 }

--- a/backend/internal/routes/public.go
+++ b/backend/internal/routes/public.go
@@ -33,7 +33,7 @@ func SetupPublicRoutes(apiRouter *mux.Router, database *db.DB, agentService *ser
 	debug.Info("Configured authentication endpoints: /login, /logout, /check-auth, /verify-mfa")
 
 	// Setup SSO routes (LDAP, SAML, OAuth/OIDC)
-	ssoManager := SetupSSORoutes(apiRouter, database.DB)
+	ssoManager := SetupSSORoutes(apiRouter, database.DB, appConfig)
 
 	// Health check endpoint - publicly accessible
 	publicRouter := apiRouter.PathPrefix("").Subrouter()

--- a/backend/internal/routes/sso.go
+++ b/backend/internal/routes/sso.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/ZerkerEOD/krakenhashes/backend/internal/config"
 	"github.com/ZerkerEOD/krakenhashes/backend/internal/db"
 	"github.com/ZerkerEOD/krakenhashes/backend/internal/handlers/auth"
 	"github.com/ZerkerEOD/krakenhashes/backend/internal/repository"
@@ -16,7 +17,7 @@ import (
 )
 
 // SetupSSORoutes configures all SSO authentication routes
-func SetupSSORoutes(apiRouter *mux.Router, sqlDB *sql.DB) *sso.Manager {
+func SetupSSORoutes(apiRouter *mux.Router, sqlDB *sql.DB, appConfig *config.Config) *sso.Manager {
 	debug.Debug("Setting up SSO routes")
 
 	// Create db wrapper
@@ -40,7 +41,7 @@ func SetupSSORoutes(apiRouter *mux.Router, sqlDB *sql.DB) *sso.Manager {
 	}
 
 	// Create SSO handler
-	ssoHandler := auth.NewSSOHandler(database, ssoManager, ssoRepo)
+	ssoHandler := auth.NewSSOHandler(database, ssoManager, ssoRepo, appConfig.ExternalURL)
 
 	// Public SSO routes (no authentication required)
 	// List enabled providers for login page


### PR DESCRIPTION
When running Krakenhashes on a nonstandard port (8443) with traefik. I noticed when trying to sign through SSO that Krakenhashes would redirect back without the port attached to the hostname. This should fix that.