### PR TITLE
fix(backend): tolerate dev DB ahead of bundled migrations + timestamp migration naming

### DIFF
--- a/backend/db/migrations/README.md
+++ b/backend/db/migrations/README.md
@@ -1,0 +1,49 @@
+# Database migrations
+
+Applied automatically on backend startup by `RunMigrations`
+(`backend/internal/database/database.go`) via
+[golang-migrate](https://github.com/golang-migrate/migrate). Each migration is a pair:
+`<version>_<description>.up.sql` and `<version>_<description>.down.sql`.
+
+## Naming: use a UTC timestamp for NEW migrations
+
+Historically migrations used a zero-padded sequential counter (`000001` … `000165`). That
+collides when two feature branches each grab "the next number" — both then claim the same
+version, and the DB can end up ahead of whichever branch you build next (which used to brick
+local startup).
+
+**Going forward, name new migrations with a UTC timestamp instead of the next integer:**
+
+```
+YYYYMMDDHHMMSS_short_description.up.sql
+YYYYMMDDHHMMSS_short_description.down.sql
+# e.g. 20260706143000_add_widget_flag.up.sql
+```
+
+A timestamp is always larger than the old 6-digit versions, so it sorts after them, and two
+branches created minutes apart never collide. Once you switch to timestamps, don't go back to
+sequential numbers — a new `000166` would sort *before* the timestamped migrations.
+
+Keep migrations additive and idempotent where you can (`ADD COLUMN IF NOT EXISTS`,
+`ALTER TYPE ... ADD VALUE IF NOT EXISTS`). Postgres enum values can't be removed, so their
+`.down.sql` is a no-op with an explanatory comment.
+
+## Dev tolerance for a "database ahead" state
+
+golang-migrate is strictly linear and refuses to start when the database records a version
+that has no migration file in the running build — which happens in development when you switch
+to a branch that lacks a migration another branch already applied to the shared dev database.
+To keep that from bricking local startup, `RunMigrations` tolerates this case in **dev only**:
+
+- Enabled implicitly when `DEBUG=true` (the dev default), or explicitly with
+  `KH_MIGRATE_ALLOW_AHEAD=true`.
+- It logs a warning and continues **without** applying migrations.
+- Production (`DEBUG=false`, flag unset) keeps this fatal — a DB ahead of the deployed code is
+  a real problem there and should stop startup.
+
+To instead realign a dev database's marker with the current branch, set
+`schema_migrations.version` to the branch's highest migration number and `dirty=false`, e.g.:
+
+```sql
+UPDATE schema_migrations SET version = 164, dirty = false;
+```

--- a/backend/internal/database/database.go
+++ b/backend/internal/database/database.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -126,6 +127,21 @@ func RunMigrations() error {
 			debug.Error("Check the logs from the *first* time migration %d failed for the specific SQL error.", e.Version)
 			debug.Error("You may need to manually clean the database and reset the migration version. Original error: %v", err)
 			return fmt.Errorf("dirty migration version %d: %w", e.Version, err)
+		} else if isDBAheadOfMigrations(err) && migrateAllowAhead() {
+			// The database records a schema version that has no migration file in this
+			// build — i.e. the DB is AHEAD of the migrations bundled here. This happens in
+			// development when switching to a branch that lacks a migration another branch
+			// already applied to the shared dev database. Tolerate it (dev only) instead of
+			// refusing to start; production keeps this fatal (DEBUG off, flag unset).
+			if version, dirty, verr := m.Version(); verr == nil {
+				debug.Warning("Database schema version %d (dirty=%t) is AHEAD of the migrations bundled in this build; "+
+					"continuing WITHOUT applying migrations (dev tolerance). This is expected when switching between "+
+					"feature branches on a shared dev database. Set KH_MIGRATE_ALLOW_AHEAD=false (or DEBUG=false) to make "+
+					"it fatal. Underlying error: %v", version, dirty, err)
+			} else {
+				debug.Warning("Database is AHEAD of the migrations bundled in this build; continuing without applying "+
+					"migrations (dev tolerance). Underlying error: %v", err)
+			}
 		} else {
 			// Handle other migration errors
 			debug.Error("Migration failed with unexpected error: %v", err)
@@ -136,6 +152,28 @@ func RunMigrations() error {
 	}
 
 	return nil
+}
+
+// migrateAllowAhead reports whether RunMigrations should tolerate a database that is
+// ahead of the migrations bundled in this build. Enabled explicitly with
+// KH_MIGRATE_ALLOW_AHEAD=true, and implicitly in debug/dev mode (DEBUG=true) so that
+// switching between feature branches on a shared dev database does not brick startup.
+// Production (DEBUG=false, flag unset) keeps migrations strict.
+func migrateAllowAhead() bool {
+	switch strings.ToLower(os.Getenv("KH_MIGRATE_ALLOW_AHEAD")) {
+	case "true", "1", "yes":
+		return true
+	case "false", "0", "no":
+		return false
+	}
+	return strings.ToLower(os.Getenv("DEBUG")) == "true"
+}
+
+// isDBAheadOfMigrations reports whether a migrate error indicates the database's recorded
+// version has no corresponding migration file in this build (the file source returns
+// os.ErrNotExist for the missing version).
+func isDBAheadOfMigrations(err error) bool {
+	return errors.Is(err, os.ErrNotExist) || strings.Contains(err.Error(), "file does not exist")
 }
 
 /*


### PR DESCRIPTION
## Summary
Prevents the class of failure that just bricked local login: golang-migrate exits on startup when the database records a schema version with no migration file in the running build. That happens in dev when you switch to a branch lacking a migration another branch already applied to the shared dev DB (e.g. building the SSL branch against a DB carrying the analytics branch's `000165`).

## Changes
- **Dev-only tolerance** in `RunMigrations`: when the DB is *ahead* of the bundled migrations, log a warning and continue instead of exiting — gated on `KH_MIGRATE_ALLOW_AHEAD=true` or implicitly `DEBUG=true`. **Production stays strict** (DEBUG off + flag unset → still fatal, which is correct there).
- **`backend/db/migrations/README.md`**: documents the tolerance flag and a going-forward convention — name **new** migrations with a UTC timestamp (`YYYYMMDDHHMMSS_desc`) instead of a sequential counter, so two branches can't collide on "the next number." Existing `000xxx` migrations stay as-is (timestamps sort after them).

## Testing
- Normal boot path is unchanged (tolerance only triggers on the specific "file does not exist for current version" error). Rebuild and confirm the backend boots and applies migrations as usual.
- To exercise the tolerance: with `DEBUG=true`, set `schema_migrations.version` above the branch's highest migration → backend now logs a warning and starts instead of crashing.
