### PR TITLE
fix(backend): harden multi-team client access (#48 + client IDOR leaks)

### DIFF
--- a/backend/internal/handlers/admin/client/client_handler.go
+++ b/backend/internal/handlers/admin/client/client_handler.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -33,6 +34,29 @@ func NewClientHandler(cr *repository.ClientRepository, cs *clientsvc.ClientServi
 		teamService:    ts,
 		clientTeamRepo: ctr,
 	}
+}
+
+// checkClientAccess returns an HTTP status and message when the caller may not access the
+// given client (teams enabled, non-admin, and the client is not assigned to one of the
+// user's teams), or (0, "") when access is allowed. A client the user cannot see is reported
+// as 404 to avoid confirming its existence. When teams are disabled it always allows.
+func (h *ClientHandler) checkClientAccess(ctx context.Context, clientID uuid.UUID) (int, string) {
+	if h.teamService == nil || !h.teamService.IsTeamsEnabled(ctx) || middleware.IsAdminFromContext(ctx) {
+		return 0, ""
+	}
+	userID, ok := middleware.GetUserIDFromContext(ctx)
+	if !ok {
+		return http.StatusUnauthorized, "Unauthorized"
+	}
+	canAccess, err := h.teamService.CanUserAccessClient(ctx, userID, clientID, false)
+	if err != nil {
+		debug.Error("Failed to check client access for %s: %v", clientID, err)
+		return http.StatusInternalServerError, "Failed to verify client access"
+	}
+	if !canAccess {
+		return http.StatusNotFound, "Client not found"
+	}
+	return 0, ""
 }
 
 // ListClients godoc
@@ -207,6 +231,11 @@ func (h *ClientHandler) GetClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if status, msg := h.checkClientAccess(r.Context(), clientID); status != 0 {
+		httputil.RespondWithError(w, status, msg)
+		return
+	}
+
 	client, err := h.clientRepo.GetByID(r.Context(), clientID)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
@@ -241,6 +270,11 @@ func (h *ClientHandler) UpdateClient(w http.ResponseWriter, r *http.Request) {
 	clientID, err := uuid.Parse(vars["id"])
 	if err != nil {
 		httputil.RespondWithError(w, http.StatusBadRequest, "Invalid client ID format")
+		return
+	}
+
+	if status, msg := h.checkClientAccess(r.Context(), clientID); status != 0 {
+		httputil.RespondWithError(w, status, msg)
 		return
 	}
 
@@ -324,6 +358,11 @@ func (h *ClientHandler) DeleteClient(w http.ResponseWriter, r *http.Request) {
 	clientID, err := uuid.Parse(vars["id"])
 	if err != nil {
 		httputil.RespondWithError(w, http.StatusBadRequest, "Invalid client ID format")
+		return
+	}
+
+	if status, msg := h.checkClientAccess(r.Context(), clientID); status != 0 {
+		httputil.RespondWithError(w, status, msg)
 		return
 	}
 

--- a/backend/internal/handlers/api/v1/client_handler.go
+++ b/backend/internal/handlers/api/v1/client_handler.go
@@ -94,6 +94,31 @@ func getUserID(r *http.Request) (uuid.UUID, error) {
 	return userID, nil
 }
 
+// checkClientAccess returns (status, code, message) when the caller may not access the given
+// client (teams enabled and the client is not assigned to one of the caller's teams), or
+// (0, "", "") when allowed. A client the caller cannot see is reported as 404 to avoid
+// confirming its existence. When teams are disabled, clients are shared and access is allowed.
+func (h *ClientHandler) checkClientAccess(r *http.Request, clientID uuid.UUID) (int, string, string) {
+	ctx := r.Context()
+	if h.teamService == nil || !h.teamService.IsTeamsEnabled(ctx) {
+		return 0, "", ""
+	}
+	userID, err := getUserID(r)
+	if err != nil {
+		return http.StatusUnauthorized, "AUTH_REQUIRED", "Authentication required"
+	}
+	// User API keys are user-scoped (no admin bypass, mirroring CreateClient here).
+	canAccess, err := h.teamService.CanUserAccessClient(ctx, userID, clientID, false)
+	if err != nil {
+		debug.Error("Failed to check client access for %s: %v", clientID, err)
+		return http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to verify client access"
+	}
+	if !canAccess {
+		return http.StatusNotFound, "RESOURCE_NOT_FOUND", "Client not found"
+	}
+	return 0, "", ""
+}
+
 // hasHashlists checks if a client has any associated hashlists
 func (h *ClientHandler) hasHashlists(ctx context.Context, clientID uuid.UUID) (bool, error) {
 	query := `SELECT EXISTS(SELECT 1 FROM hashlists WHERE client_id = $1)`
@@ -240,8 +265,25 @@ func (h *ClientHandler) ListClients(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Get all clients (clients are global resources)
-	allClients, err := h.clientRepo.List(r.Context())
+	// Scope clients to the caller's teams when teams are enabled; otherwise clients are shared.
+	ctx := r.Context()
+	var allClients []models.Client
+	var err error
+	if h.teamService != nil && h.teamService.IsTeamsEnabled(ctx) {
+		userID, uerr := getUserID(r)
+		if uerr != nil {
+			sendAPIError(w, "Authentication required", "AUTH_REQUIRED", http.StatusUnauthorized)
+			return
+		}
+		teamIDs, terr := h.teamService.GetUserTeamIDs(ctx, userID)
+		if terr != nil || len(teamIDs) == 0 {
+			allClients = []models.Client{} // fail closed: no accessible clients
+		} else {
+			allClients, err = h.clientTeamRepo.GetClientsForTeams(ctx, teamIDs)
+		}
+	} else {
+		allClients, err = h.clientRepo.List(ctx)
+	}
 	if err != nil {
 		debug.Error("Failed to list clients: %v", err)
 		sendAPIError(w, "Failed to retrieve clients", "INTERNAL_ERROR", http.StatusInternalServerError)
@@ -288,7 +330,11 @@ func (h *ClientHandler) GetClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get client (clients are global resources - no ownership check needed)
+	if status, code, msg := h.checkClientAccess(r, clientID); status != 0 {
+		sendAPIError(w, msg, code, status)
+		return
+	}
+
 	client, err := h.clientRepo.GetByID(r.Context(), clientID)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
@@ -312,6 +358,11 @@ func (h *ClientHandler) UpdateClient(w http.ResponseWriter, r *http.Request) {
 	clientID, err := uuid.Parse(vars["id"])
 	if err != nil {
 		sendAPIError(w, "Invalid client ID format", "VALIDATION_ERROR", http.StatusBadRequest)
+		return
+	}
+
+	if status, code, msg := h.checkClientAccess(r, clientID); status != 0 {
+		sendAPIError(w, msg, code, status)
 		return
 	}
 
@@ -376,6 +427,11 @@ func (h *ClientHandler) DeleteClient(w http.ResponseWriter, r *http.Request) {
 	clientID, err := uuid.Parse(vars["id"])
 	if err != nil {
 		sendAPIError(w, "Invalid client ID format", "VALIDATION_ERROR", http.StatusBadRequest)
+		return
+	}
+
+	if status, code, msg := h.checkClientAccess(r, clientID); status != 0 {
+		sendAPIError(w, msg, code, status)
 		return
 	}
 

--- a/backend/internal/handlers/jobs/user_jobs.go
+++ b/backend/internal/handlers/jobs/user_jobs.go
@@ -219,9 +219,10 @@ func (h *UserJobsHandler) ListJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get status counts (filtered by team when applicable)
+	// Get status counts (team-scoped whenever teams are enabled, so a non-admin with no
+	// teams gets scoped/empty counts rather than the global tally).
 	var statusCounts map[string]int
-	if len(filter.TeamIDs) > 0 {
+	if filter.TeamsEnabled {
 		statusCounts, err = h.jobExecRepo.GetStatusCountsFiltered(ctx, filter)
 	} else {
 		statusCounts, err = h.jobExecRepo.GetStatusCounts(ctx)

--- a/backend/internal/repository/hashlist_repository.go
+++ b/backend/internal/repository/hashlist_repository.go
@@ -1526,12 +1526,21 @@ func (r *HashListRepository) ListWithTeamFilter(ctx context.Context, params List
 	}
 
 	// Filter via client_teams join
+	// NOTE: joins clients (c) so the team-scoped path returns the client name and the
+	// client potfile-policy flags at parity with List(); without this, non-admin team
+	// members see "-" for the client and the potfile-removal actions are disabled (#48).
 	baseQuery = fmt.Sprintf(`
 		SELECT DISTINCT h.id, h.name, h.hash_type_id, h.total_hashes, h.cracked_hashes,
 		       h.user_id, h.client_id, h.status, h.created_at, h.updated_at, h.archived_at,
-		       h.invalid_count, h.total_input_lines, h.validation_notice
+		       h.invalid_count, h.total_input_lines, h.validation_notice,
+		       c.name AS client_name,
+		       c.exclude_from_potfile AS client_exclude_from_global,
+		       c.exclude_from_client_potfile AS client_exclude_from_client,
+		       c.remove_from_global_potfile_on_hashlist_delete,
+		       c.remove_from_client_potfile_on_hashlist_delete
 		FROM hashlists h
 		LEFT JOIN client_teams ct ON h.client_id = ct.client_id
+		LEFT JOIN clients c ON h.client_id = c.id
 		WHERE (
 			ct.team_id IN (%s)`, strings.Join(teamPlaceholders, ", "))
 
@@ -1602,10 +1611,18 @@ func (r *HashListRepository) ListWithTeamFilter(ctx context.Context, params List
 		var clientID sql.Null[uuid.UUID]
 		var archivedAt sql.NullTime
 		var validationNoticeNS sql.NullString
+		var clientName sql.NullString
+		var clientExcludeFromGlobalPotfile sql.NullBool
+		var clientExcludeFromClientPotfile sql.NullBool
+		var clientRemoveFromGlobalOnDelete sql.NullBool
+		var clientRemoveFromClientOnDelete sql.NullBool
 		err := rows.Scan(
 			&h.ID, &h.Name, &h.HashTypeID, &h.TotalHashes, &h.CrackedHashes,
 			&h.UserID, &clientID, &h.Status, &h.CreatedAt, &h.UpdatedAt, &archivedAt,
 			&h.InvalidCount, &h.TotalInputLines, &validationNoticeNS,
+			&clientName,
+			&clientExcludeFromGlobalPotfile, &clientExcludeFromClientPotfile,
+			&clientRemoveFromGlobalOnDelete, &clientRemoveFromClientOnDelete,
 		)
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to scan hashlist: %w", err)
@@ -1619,6 +1636,21 @@ func (r *HashListRepository) ListWithTeamFilter(ctx context.Context, params List
 		}
 		if validationNoticeNS.Valid {
 			h.ValidationNotice = &validationNoticeNS.String
+		}
+		if clientName.Valid {
+			h.ClientName = &clientName.String
+		}
+		if clientExcludeFromGlobalPotfile.Valid {
+			h.ClientExcludeFromGlobalPotfile = &clientExcludeFromGlobalPotfile.Bool
+		}
+		if clientExcludeFromClientPotfile.Valid {
+			h.ClientExcludeFromClientPotfile = &clientExcludeFromClientPotfile.Bool
+		}
+		if clientRemoveFromGlobalOnDelete.Valid {
+			h.ClientRemoveFromGlobalOnDelete = &clientRemoveFromGlobalOnDelete.Bool
+		}
+		if clientRemoveFromClientOnDelete.Valid {
+			h.ClientRemoveFromClientOnDelete = &clientRemoveFromClientOnDelete.Bool
 		}
 
 		hashlists = append(hashlists, h)

--- a/backend/internal/repository/job_execution_repository_extension.go
+++ b/backend/internal/repository/job_execution_repository_extension.go
@@ -342,6 +342,11 @@ func (r *JobExecutionRepository) GetStatusCountsFiltered(ctx context.Context, fi
 		args = append(args, *filter.UserID)
 	}
 
+	// Teams enabled but no teams — fail-closed: no results (mirror GetFilteredCount).
+	if filter.TeamsEnabled && len(filter.TeamIDs) == 0 {
+		return map[string]int{}, nil
+	}
+
 	// Apply team filter
 	if len(filter.TeamIDs) > 0 {
 		teamIDStrs := make([]string, len(filter.TeamIDs))


### PR DESCRIPTION
## Summary
Hardens multi-team client access. Fixes the reported #48 (client name shows as "-" for non-admin team members) plus two client IDOR leaks and a status-count leak found alongside it. These bring the code in line with the **documented** team-access model (a client not assigned to a team you belong to is invisible to you — see `docs/user-guide/teams.md`).

### Fixes
- **#48 (over-restriction):** the team-scoped hashlist list (`ListWithTeamFilter`) now `LEFT JOIN`s clients and returns `client_name` + the client potfile-policy flags at parity with the admin `List` path. Non-admin team members now see the client name (was `-`) and the potfile-removal actions work again.
- **Client IDOR — web (High):** `GET/PUT/DELETE /clients/{id}` (mounted for all authenticated users) now gate on team access via `CanUserAccessClient`; a client outside the caller's teams returns 404 (no enumeration).
- **Client IDOR — user API v1 (High):** same gate on `GET/PATCH/DELETE /api/v1/clients/{id}`, and `GET /api/v1/clients` is scoped to the caller's teams.
- **Status-count leak (Low):** `ListJobs` uses team-filtered status counts whenever teams are enabled, and `GetStatusCountsFiltered` fails closed (empty) for a caller with no teams — so a non-admin with zero teams no longer sees global job-status tallies.

Admins and the teams-disabled path are unchanged (clients remain shared when teams are off).

### Security
All gates reuse the existing `CanUserAccessClient` / team-membership primitives, fail closed, and return 404 for out-of-team clients to avoid confirming their existence.

### Testing
Verified in dev with teams enabled as a non-admin member: client name shows on /hashlists; out-of-team clients return 404 on web + v1 API; the v1 client list is scoped to the caller's teams; a zero-team user gets scoped job-status counts.

### Docs
No documentation change needed — `docs/user-guide/teams.md` already describes this exact access model ("a client is invisible to you unless assigned to a team you belong to"). This PR makes the code enforce what the docs already promise.

Fixes #48.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This change hardens team-scoped client access and closes a couple of information leaks: non-admin users now see client names and policy flags correctly in team-scoped hashlist results, client CRUD endpoints enforce team membership, and job status counts no longer fall back to global data when teams are enabled.

- **Backend**
  - Team-scoped hashlist listing now `LEFT JOIN`s clients so non-admin team members get `client_name` plus potfile/removal policy fields instead of `"-"`.
  - Client handlers in both admin and API v1 now verify access with `CanUserAccessClient` and return `404` for out-of-team clients, preventing IDOR-style leakage.
  - `GET /api/v1/clients` is now scoped to the caller’s teams when teams are enabled and fails closed if team IDs cannot be resolved.
  - Job status counts now use the team-filtered query whenever teams are enabled, and empty team membership returns empty counts instead of global totals.
  - **API/behavior change:** client endpoints are now team-restricted for non-admin users; inaccessible clients are hidden behind `404`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->