### PR TITLE
fix(frontend): wrap long Original Hash in-column on the hashlist table (#50)

### DIFF
--- a/frontend/src/components/hashlist/HashlistHashesTable.tsx
+++ b/frontend/src/components/hashlist/HashlistHashesTable.tsx
@@ -208,23 +208,18 @@ export default function HashlistHashesTable({
         </Box>
 
         <TableContainer sx={{ overflowX: 'auto' }}>
-          <Table size="small" aria-label="hashlist hashes table">
+          {/* tableLayout: 'fixed' bounds each column so a long Original Hash wraps within
+              its own column (wordBreak on the cell) instead of overflowing into the
+              Username/Domain columns (#50). */}
+          <Table size="small" aria-label="hashlist hashes table" sx={{ tableLayout: 'fixed' }}>
             <TableHead>
               <TableRow>
-                <TableCell sx={{ minWidth: 300, maxWidth: 600 }}>
-                  Original Hash
-                </TableCell>
-                <TableCell sx={{ minWidth: 120, width: 150 }}>
-                  Username
-                </TableCell>
-                <TableCell sx={{ minWidth: 120, width: 150 }}>
-                  Domain
-                </TableCell>
-                <TableCell sx={{ minWidth: 120, width: 150 }}>
-                  Password
-                </TableCell>
-                <TableCell sx={{ width: 100 }}>Status</TableCell>
-                <TableCell sx={{ width: 80 }} align="center">
+                <TableCell sx={{ width: '40%' }}>Original Hash</TableCell>
+                <TableCell sx={{ width: '15%' }}>Username</TableCell>
+                <TableCell sx={{ width: '15%' }}>Domain</TableCell>
+                <TableCell sx={{ width: '16%' }}>Password</TableCell>
+                <TableCell sx={{ width: '8%' }}>Status</TableCell>
+                <TableCell sx={{ width: '6%' }} align="center">
                   Actions
                 </TableCell>
               </TableRow>
@@ -237,7 +232,6 @@ export default function HashlistHashesTable({
                       fontFamily: 'monospace',
                       fontSize: '0.875rem',
                       wordBreak: 'break-all',
-                      maxWidth: 600,
                     }}
                   >
                     {hash.original_hash}


### PR DESCRIPTION
## Summary
Fixes #50 — a long Original Hash (e.g. `$office$...`) overflowed into the Domain/Username columns and obscured them.

The hashes table (`HashlistHashesTable.tsx`) used the browser default `table-layout: auto`, so the `maxWidth` on the hash cell was ignored and a long unbreakable hash pushed the column past its cap. Switched the table to `tableLayout: 'fixed'` with explicit column widths and kept `wordBreak: 'break-all'` on the Original Hash cell, so long hashes now **wrap within their own column** (the "line break" the reporter asked for) instead of spilling into adjacent columns. Same fixed-layout approach already used by `PotTable.tsx`.

Column widths: Original Hash 40%, Username 15%, Domain 15%, Password 16%, Status 8%, Actions 6% — easy to tweak if different proportions read better.

## Testing
Open a hashlist containing a long office/PDF hash → the hash wraps inside the Original Hash column; Username / Domain / Password stay in their own columns and readable. Short hashes look unchanged.

## Docs
None needed (rendering fix).

Fixes #50.
