### PR TITLE
perf(backend,frontend): kill jobs-list N+1, poll jobs every 2s (#51)

### DIFF
--- a/backend/internal/handlers/jobs/user_jobs.go
+++ b/backend/internal/handlers/jobs/user_jobs.go
@@ -233,22 +233,37 @@ func (h *UserJobsHandler) ListJobs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Convert to job summaries
+	// Batch-load the page's hashlists and tasks in one query each to avoid an N+1
+	// (previously two queries per job, which is why the UI poll was throttled to 5s).
+	hashlistIDs := make([]int64, 0, len(jobsWithUser))
+	jobIDs := make([]uuid.UUID, 0, len(jobsWithUser))
+	for _, jw := range jobsWithUser {
+		hashlistIDs = append(hashlistIDs, jw.JobExecution.HashlistID)
+		jobIDs = append(jobIDs, jw.JobExecution.ID)
+	}
+	hashlistsByID, err := h.hashlistRepo.GetByIDs(ctx, hashlistIDs)
+	if err != nil {
+		debug.Error("Failed to batch-load hashlists: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	tasksByJob, err := h.jobTaskRepo.GetTasksByJobExecutions(ctx, jobIDs)
+	if err != nil {
+		debug.Error("Failed to batch-load tasks: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
 	summaries := make([]JobSummary, 0, len(jobsWithUser))
 	for _, jobWithUser := range jobsWithUser {
 		job := jobWithUser.JobExecution
-		// Get hashlist details including cracked count
-		hashlist, err := h.hashlistRepo.GetByID(ctx, job.HashlistID)
-		if err != nil {
-			debug.Error("Failed to get hashlist %d: %v", job.HashlistID, err)
+		// Hashlist + tasks from the batch loads above (nil-safe: absent = skip / no tasks).
+		hashlist, ok := hashlistsByID[job.HashlistID]
+		if !ok {
+			debug.Error("Hashlist %d not found for job %s", job.HashlistID, job.ID)
 			continue
 		}
-
-		// Get task statistics
-		tasks, err := h.jobTaskRepo.GetTasksByJobExecution(ctx, job.ID)
-		if err != nil {
-			debug.Error("Failed to get tasks for job %s: %v", job.ID, err)
-			tasks = []models.JobTask{}
-		}
+		tasks := tasksByJob[job.ID]
 
 		// Calculate metrics
 		var agentCount int
@@ -2230,22 +2245,37 @@ func (h *UserJobsHandler) ListUserJobs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Convert to job summaries (reuse the same logic as ListJobs)
+	// Batch-load the page's hashlists and tasks in one query each to avoid an N+1
+	// (previously two queries per job, which is why the UI poll was throttled to 5s).
+	hashlistIDs := make([]int64, 0, len(jobsWithUser))
+	jobIDs := make([]uuid.UUID, 0, len(jobsWithUser))
+	for _, jw := range jobsWithUser {
+		hashlistIDs = append(hashlistIDs, jw.JobExecution.HashlistID)
+		jobIDs = append(jobIDs, jw.JobExecution.ID)
+	}
+	hashlistsByID, err := h.hashlistRepo.GetByIDs(ctx, hashlistIDs)
+	if err != nil {
+		debug.Error("Failed to batch-load hashlists: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+	tasksByJob, err := h.jobTaskRepo.GetTasksByJobExecutions(ctx, jobIDs)
+	if err != nil {
+		debug.Error("Failed to batch-load tasks: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
 	summaries := make([]JobSummary, 0, len(jobsWithUser))
 	for _, jobWithUser := range jobsWithUser {
 		job := jobWithUser.JobExecution
-		// Get hashlist details including cracked count
-		hashlist, err := h.hashlistRepo.GetByID(ctx, job.HashlistID)
-		if err != nil {
-			debug.Error("Failed to get hashlist %d: %v", job.HashlistID, err)
+		// Hashlist + tasks from the batch loads above (nil-safe: absent = skip / no tasks).
+		hashlist, ok := hashlistsByID[job.HashlistID]
+		if !ok {
+			debug.Error("Hashlist %d not found for job %s", job.HashlistID, job.ID)
 			continue
 		}
-
-		// Get task statistics
-		tasks, err := h.jobTaskRepo.GetTasksByJobExecution(ctx, job.ID)
-		if err != nil {
-			debug.Error("Failed to get tasks for job %s: %v", job.ID, err)
-			tasks = []models.JobTask{}
-		}
+		tasks := tasksByJob[job.ID]
 
 		// Calculate metrics
 		var agentCount int

--- a/backend/internal/repository/hashlist_repository.go
+++ b/backend/internal/repository/hashlist_repository.go
@@ -280,6 +280,107 @@ func (r *HashListRepository) GetByID(ctx context.Context, id int64) (*models.Has
 	return &hashlist, nil
 }
 
+// GetByIDs returns the given hashlists keyed by ID in a single query, to avoid an N+1 when
+// listing jobs. Missing IDs are simply absent from the returned map. Mirrors GetByID's columns.
+func (r *HashListRepository) GetByIDs(ctx context.Context, ids []int64) (map[int64]*models.HashList, error) {
+	result := make(map[int64]*models.HashList, len(ids))
+	if len(ids) == 0 {
+		return result, nil
+	}
+	query := `
+		SELECT
+			h.id, h.name, h.user_id, h.client_id, h.hash_type_id,
+			h.total_hashes, h.cracked_hashes, h.status, h.error_message,
+			h.exclude_from_potfile, h.exclude_from_client_potfile, h.original_file_path, h.has_mixed_work_factors,
+			h.invalid_count, h.total_input_lines, h.validation_notice,
+			h.created_at, h.updated_at, h.archived_at,
+			c.name AS client_name,
+			c.exclude_from_potfile AS client_exclude_from_global,
+			c.exclude_from_client_potfile AS client_exclude_from_client,
+			c.remove_from_global_potfile_on_hashlist_delete,
+			c.remove_from_client_potfile_on_hashlist_delete
+		FROM hashlists h
+		LEFT JOIN clients c ON h.client_id = c.id
+		WHERE h.id = ANY($1)`
+
+	rows, err := r.db.QueryContext(ctx, query, pq.Array(ids))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get hashlists by IDs: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var hashlist models.HashList
+		var clientID sql.Null[uuid.UUID]
+		var clientName sql.NullString
+		var originalFilePath sql.NullString
+		var archivedAt sql.NullTime
+		var clientExcludeFromGlobal sql.NullBool
+		var clientExcludeFromClient sql.NullBool
+		var clientRemoveFromGlobalOnDelete sql.NullBool
+		var clientRemoveFromClientOnDelete sql.NullBool
+		var validationNoticeNS sql.NullString
+		if err := rows.Scan(
+			&hashlist.ID,
+			&hashlist.Name,
+			&hashlist.UserID,
+			&clientID,
+			&hashlist.HashTypeID,
+			&hashlist.TotalHashes,
+			&hashlist.CrackedHashes,
+			&hashlist.Status,
+			&hashlist.ErrorMessage,
+			&hashlist.ExcludeFromPotfile,
+			&hashlist.ExcludeFromClientPotfile,
+			&originalFilePath,
+			&hashlist.HasMixedWorkFactors,
+			&hashlist.InvalidCount,
+			&hashlist.TotalInputLines,
+			&validationNoticeNS,
+			&hashlist.CreatedAt,
+			&hashlist.UpdatedAt,
+			&archivedAt,
+			&clientName,
+			&clientExcludeFromGlobal,
+			&clientExcludeFromClient,
+			&clientRemoveFromGlobalOnDelete,
+			&clientRemoveFromClientOnDelete,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan hashlist: %w", err)
+		}
+		if clientID.Valid {
+			hashlist.ClientID = clientID.V
+		}
+		if clientName.Valid {
+			hashlist.ClientName = &clientName.String
+		}
+		if originalFilePath.Valid {
+			hashlist.OriginalFilePath = &originalFilePath.String
+		}
+		if archivedAt.Valid {
+			hashlist.ArchivedAt = &archivedAt.Time
+		}
+		if clientExcludeFromGlobal.Valid {
+			hashlist.ClientExcludeFromGlobalPotfile = &clientExcludeFromGlobal.Bool
+		}
+		if clientExcludeFromClient.Valid {
+			hashlist.ClientExcludeFromClientPotfile = &clientExcludeFromClient.Bool
+		}
+		if clientRemoveFromGlobalOnDelete.Valid {
+			hashlist.ClientRemoveFromGlobalOnDelete = &clientRemoveFromGlobalOnDelete.Bool
+		}
+		if clientRemoveFromClientOnDelete.Valid {
+			hashlist.ClientRemoveFromClientOnDelete = &clientRemoveFromClientOnDelete.Bool
+		}
+		if validationNoticeNS.Valid {
+			hashlist.ValidationNotice = &validationNoticeNS.String
+		}
+		hl := hashlist
+		result[hashlist.ID] = &hl
+	}
+	return result, rows.Err()
+}
+
 // List retrieves hashlists, optionally filtered and paginated.
 type ListHashlistsParams struct {
 	UserID   *uuid.UUID

--- a/backend/internal/repository/job_task_repository.go
+++ b/backend/internal/repository/job_task_repository.go
@@ -415,6 +415,66 @@ func (r *JobTaskRepository) GetTasksByJobExecution(ctx context.Context, jobExecu
 	return tasks, nil
 }
 
+// GetTasksByJobExecutions returns the tasks for each of the given job executions in a single
+// query, grouped by job_execution_id. Used to avoid an N+1 when listing jobs. Mirrors the
+// columns of GetTasksByJobExecution.
+func (r *JobTaskRepository) GetTasksByJobExecutions(ctx context.Context, jobExecutionIDs []uuid.UUID) (map[uuid.UUID][]models.JobTask, error) {
+	result := make(map[uuid.UUID][]models.JobTask, len(jobExecutionIDs))
+	if len(jobExecutionIDs) == 0 {
+		return result, nil
+	}
+
+	placeholders := make([]string, len(jobExecutionIDs))
+	args := make([]interface{}, len(jobExecutionIDs))
+	for i, id := range jobExecutionIDs {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+		SELECT
+			jt.id, jt.job_execution_id, jt.agent_id, jt.status,
+			jt.keyspace_start, jt.keyspace_end, jt.keyspace_processed,
+			jt.effective_keyspace_start, jt.effective_keyspace_end, jt.effective_keyspace_processed,
+			jt.benchmark_speed, jt.average_speed, jt.chunk_duration, jt.assigned_at,
+			jt.started_at, jt.completed_at, jt.cracking_completed_at, jt.last_checkpoint, jt.error_message,
+			jt.crack_count,
+			jt.increment_layer_id,
+			jt.rule_start_index, jt.rule_end_index, jt.rule_chunk_path, jt.is_rule_split_task,
+			jt.progress_percent,
+			a.name as agent_name
+		FROM job_tasks jt
+		LEFT JOIN agents a ON jt.agent_id = a.id
+		WHERE jt.job_execution_id IN (%s)
+		ORDER BY jt.job_execution_id, jt.keyspace_start ASC`, strings.Join(placeholders, ", "))
+
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tasks by job executions: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var task models.JobTask
+		if err := rows.Scan(
+			&task.ID, &task.JobExecutionID, &task.AgentID, &task.Status,
+			&task.KeyspaceStart, &task.KeyspaceEnd, &task.KeyspaceProcessed,
+			&task.EffectiveKeyspaceStart, &task.EffectiveKeyspaceEnd, &task.EffectiveKeyspaceProcessed,
+			&task.BenchmarkSpeed, &task.AverageSpeed, &task.ChunkDuration, &task.AssignedAt,
+			&task.StartedAt, &task.CompletedAt, &task.CrackingCompletedAt, &task.LastCheckpoint, &task.ErrorMessage,
+			&task.CrackCount,
+			&task.IncrementLayerID,
+			&task.RuleStartIndex, &task.RuleEndIndex, &task.RuleChunkPath, &task.IsRuleSplitTask,
+			&task.ProgressPercent,
+			&task.AgentName,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan job task: %w", err)
+		}
+		result[task.JobExecutionID] = append(result[task.JobExecutionID], task)
+	}
+	return result, rows.Err()
+}
+
 // GetActiveTasksByAgent retrieves active tasks for an agent
 func (r *JobTaskRepository) GetActiveTasksByAgent(ctx context.Context, agentID int) ([]models.JobTask, error) {
 	debug.Info("GetActiveTasksByAgent called for agent %d", agentID)

--- a/frontend/src/pages/Jobs/JobDetails.tsx
+++ b/frontend/src/pages/Jobs/JobDetails.tsx
@@ -166,12 +166,12 @@ const JobDetails: React.FC = () => {
       const interval = setInterval(() => {
         // Check conditions again inside the interval
         const activeStatuses = ['pending', 'running', 'paused'];
-        if (activeStatuses.includes(currentStatusRef.current) && 
+        if (activeStatuses.includes(currentStatusRef.current) &&
             !isEditingRef.current &&
             autoRefreshEnabled) {
           fetchJobDetails();
         }
-      }, 5000);
+      }, 2000);
       
       pollingIntervalRef.current = interval;
     }

--- a/frontend/src/pages/Jobs/index.tsx
+++ b/frontend/src/pages/Jobs/index.tsx
@@ -173,10 +173,11 @@ const Jobs: React.FC = () => {
       clearInterval(pollingTimer.current);
     }
 
-    // Set up new polling timer
+    // Set up new polling timer (2s — the jobs list is cheap to serve after the N+1 fix, so
+    // the UI reflects task changes faster without extra DB load).
     pollingTimer.current = setInterval(() => {
       fetchJobs(false); // Don't show loading indicator for polling updates
-    }, 5000);
+    }, 2000);
 
     // Cleanup on unmount or when polling is disabled
     return () => {


### PR DESCRIPTION
## Summary
Improves #51 (UI lagging behind running-task state). The jobs list ran an N+1 — two queries per job (hashlist + tasks) on every request — so the poll was throttled to 5s to limit DB load, which is what made task state changes lag in the UI.

## Changes
- **Killed the N+1:** new batch loaders `HashListRepository.GetByIDs` and `JobTaskRepository.GetTasksByJobExecutions` (one query each), used in **both** `ListJobs` (`/api/jobs`) and `ListUserJobs` (`/api/user/jobs`). A page of N jobs now costs **~5 queries instead of ~2N+3** (e.g. ~5 vs ~53 for 25 jobs).
- **Faster poll:** Jobs-list and Job-detail poll lowered **5s → 2s**. Because each poll is now cheap, the UI reflects task changes ~2.5× faster while cutting overall DB load (~4× less than the old 5s poll).

## Testing
- Correctness: `/jobs` and the Dashboard render every column correctly after the batch refactor (job name, hashlist name, progress, agent count, cracked, speed, priority); job-detail page too; empty page and jobs-with-no-tasks render fine.
- Latency: a completing mock-agent task reflects in the UI within ~2s.

## Deferred follow-ups
- **ETag/304 conditional responses** — make idle polls near-free; much less critical now that per-poll query count is a small constant.
- **Real-time WebSocket push** — the ultimate "instant" sync; larger change.

Keeping #51 open for the WebSocket follow-up.

Refs #51.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR reduces jobs UI latency by replacing per-job database lookups with batch loading and by refreshing the jobs UI more frequently. It improves query efficiency for both the main jobs list and user jobs list while keeping the UI responsive to task-state changes.

- Backend
  - Added batch repository methods to fetch multiple hashlists and job-task sets in single queries.
  - Updated job list handlers to prefetch data once per page and build job summaries from cached maps instead of issuing per-job queries.
  - Missing hashlists are now logged and skipped during summary construction.

- Frontend
  - Reduced polling intervals on the jobs list and job details pages from 5s to 2s.
  - Kept polling guarded by the existing active-status/editing checks so refreshes only happen when appropriate.

- Database / API
  - No migrations.
  - No API contract changes.
  - No breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->