### PR TITLE
feat(backend,frontend): hybrid job naming + Hashlist/Preset jobs column (#49)

### DIFF
--- a/backend/internal/handlers/jobs/user_jobs.go
+++ b/backend/internal/handlers/jobs/user_jobs.go
@@ -117,6 +117,7 @@ type JobSummary struct {
 	Name                   string  `json:"name"`
 	HashlistID             int64   `json:"hashlist_id"`
 	HashlistName           string  `json:"hashlist_name"`
+	PresetJobName          *string `json:"preset_job_name,omitempty"`
 	Status                 string  `json:"status"`
 	Priority               int     `json:"priority"`
 	MaxAgents              int     `json:"max_agents"`
@@ -342,6 +343,7 @@ func (h *UserJobsHandler) ListJobs(w http.ResponseWriter, r *http.Request) {
 			Name:                   getJobName(job, hashlist),
 			HashlistID:             job.HashlistID,
 			HashlistName:           hashlist.Name,
+			PresetJobName:          jobWithUser.PresetJobName,
 			Status:                 string(job.Status),
 			Priority:               job.Priority,
 			MaxAgents:              job.MaxAgents,
@@ -414,6 +416,8 @@ type JobNameConfig struct {
 	IncrementMode           string // "off", "increment", "increment_inverse"
 	HashTypeID              int
 	CustomName              string
+	HashlistName            string // Hashlist name, used for preset/workflow job names (#49)
+	PresetJobName           string // Preset name; when set, the job is named Client-Hashlist-Preset (#49)
 	AssociationWordlistName string // For association attack (mode 9)
 }
 
@@ -489,6 +493,24 @@ func generateJobName(config JobNameConfig) string {
 	// User-provided custom name takes priority
 	if config.CustomName != "" {
 		return config.CustomName
+	}
+
+	// Preset and workflow jobs are named "Client (if present) - Hashlist - Preset" (#49),
+	// keeping the previous attack-config style only for custom jobs (below).
+	if config.PresetJobName != "" {
+		var presetParts []string
+		if config.Client != nil && config.Client.Name != "" {
+			presetParts = append(presetParts, config.Client.Name)
+		}
+		if config.HashlistName != "" {
+			presetParts = append(presetParts, config.HashlistName)
+		}
+		presetParts = append(presetParts, config.PresetJobName)
+		name := strings.Join(presetParts, "-")
+		if len(name) > 255 {
+			name = truncateJobName(name, config.PresetJobName, 255)
+		}
+		return name
 	}
 
 	var parts []string
@@ -698,9 +720,11 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 			wordlistNames := h.resolveWordlistNames(ctx, presetJob.WordlistIDs)
 			ruleNames := h.resolveRuleNames(ctx, presetJob.RuleIDs)
 
-			// Generate job name based on attack configuration
+			// Generate job name based on attack configuration (preset job: Client-Hashlist-Preset, #49)
 			jobName := generateJobName(JobNameConfig{
 				Client:        client,
+				HashlistName:  hashlist.Name,
+				PresetJobName: presetJob.Name,
 				AttackMode:    presetJob.AttackMode,
 				WordlistNames: wordlistNames,
 				RuleNames:     ruleNames,
@@ -760,9 +784,11 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 				wordlistNames := h.resolveWordlistNames(ctx, presetJob.WordlistIDs)
 				ruleNames := h.resolveRuleNames(ctx, presetJob.RuleIDs)
 
-				// Generate job name for workflow step based on attack configuration
+				// Generate job name for workflow step based on attack configuration (preset job: Client-Hashlist-Preset, #49)
 				jobName := generateJobName(JobNameConfig{
 					Client:        client,
+					HashlistName:  hashlist.Name,
+					PresetJobName: presetJob.Name,
 					AttackMode:    presetJob.AttackMode,
 					WordlistNames: wordlistNames,
 					RuleNames:     ruleNames,
@@ -2339,6 +2365,7 @@ func (h *UserJobsHandler) ListUserJobs(w http.ResponseWriter, r *http.Request) {
 			Name:                   getJobName(job, hashlist),
 			HashlistID:             job.HashlistID,
 			HashlistName:           hashlist.Name,
+			PresetJobName:          jobWithUser.PresetJobName,
 			Status:                 string(job.Status),
 			Priority:               job.Priority,
 			MaxAgents:              job.MaxAgents,

--- a/backend/internal/repository/job_execution_repository_extension.go
+++ b/backend/internal/repository/job_execution_repository_extension.go
@@ -79,6 +79,7 @@ type JobFilter struct {
 type JobExecutionWithUser struct {
 	models.JobExecution
 	CreatedByUsername *string `db:"created_by_username"`
+	PresetJobName     *string `db:"preset_job_name"` // nil for custom jobs (no preset)
 }
 
 // ListWithFilters retrieves job executions with pagination and filters
@@ -558,7 +559,8 @@ func (r *JobExecutionRepository) ListWithFiltersAndUser(ctx context.Context, lim
 			je.base_keyspace, je.effective_keyspace, je.multiplication_factor, je.uses_rule_splitting,
 			je.rule_split_count, je.overall_progress_percent, je.dispatched_keyspace,
 			je.name, je.archived_at,
-			u.username as created_by_username
+			u.username as created_by_username,
+			pj.name as preset_job_name
 		FROM job_executions je
 		LEFT JOIN preset_jobs pj ON je.preset_job_id = pj.id
 		JOIN hashlists h ON je.hashlist_id = h.id
@@ -667,6 +669,7 @@ func (r *JobExecutionRepository) ListWithFiltersAndUser(ctx context.Context, lim
 			&exec.RuleSplitCount, &exec.OverallProgressPercent, &exec.DispatchedKeyspace,
 			&exec.Name, &exec.ArchivedAt,
 			&exec.CreatedByUsername,
+			&exec.PresetJobName,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan job execution with user: %w", err)

--- a/frontend/public/locales/en/dashboard.json
+++ b/frontend/public/locales/en/dashboard.json
@@ -102,7 +102,7 @@
     "completedJobs": "Completed Jobs",
     "columns": {
       "jobName": "Job Name",
-      "hashlist": "Hashlist",
+      "hashlist": "Hashlist / Preset",
       "createdBy": "Created By",
       "progress": "Progress",
       "keyspace": "Keyspace",

--- a/frontend/src/pages/Jobs/JobRow.tsx
+++ b/frontend/src/pages/Jobs/JobRow.tsx
@@ -207,12 +207,22 @@ const JobRow: React.FC<JobRowProps> = ({ job, onJobUpdated, isLastActiveJob, isC
           </Box>
         </TableCell>
 
-        {/* Hashlist */}
+        {/* Hashlist / Preset */}
         <TableCell>
           <Box>
-            <Typography variant="body2">{job.hashlist_name}</Typography>
+            <Link
+              component="button"
+              variant="body2"
+              onClick={() => navigate(`/hashlists/${job.hashlist_id}`)}
+              sx={{ textAlign: 'left', display: 'block' }}
+            >
+              {job.hashlist_name}
+            </Link>
+            <Typography variant="caption" color="text.secondary" display="block">
+              {job.preset_job_name || 'N/A'}
+            </Typography>
             {completionTime && (
-              <Typography variant="caption" color="text.secondary">
+              <Typography variant="caption" color="text.secondary" display="block">
                 {t('row.completed')} {completionTime}
               </Typography>
             )}

--- a/frontend/src/types/jobs.ts
+++ b/frontend/src/types/jobs.ts
@@ -11,6 +11,7 @@ export interface JobSummary {
   name: string;
   hashlist_id: number;
   hashlist_name: string;
+  preset_job_name?: string; // undefined for custom jobs (no preset)
   status: JobStatus;
   priority: number;
   max_agents: number;


### PR DESCRIPTION
## Summary
Implements #49 and adds the jobs-table UX you asked for.

### Hybrid job naming (#49)
- New **preset** and **workflow** jobs are named `Client-Hashlist-Preset` (client only when present).
- **Custom** jobs keep the existing attack-config style.
- Existing jobs are unchanged (names are stored at creation, so this is going-forward only).
- The separate programmatic `/api/v1/jobs` endpoint keeps its own naming (it takes a user-supplied name).

### "Hashlist / Preset" column + links
Affects both the Jobs page and the Dashboard (shared `JobRow`/`JobsTable`):
- Column two header is now **"Hashlist / Preset"**.
- The **hashlist name is now a link** to the hashlist page.
- The **preset name shows underneath**, or **"N/A"** for custom jobs.
- Backend: `JobSummary` carries `preset_job_name`, sourced from `pj.name` on the `preset_jobs` join that `ListWithFiltersAndUser` already had (no extra query, no N+1).

## Testing
- Create a job from a preset and from a workflow: name is `Client-Hashlist-Preset`. Create a custom job: name keeps the old attack-config style.
- Jobs page and Dashboard: column two shows the hashlist name as a clickable link, with the preset name (or "N/A") underneath.

## Notes
- Header label localized in English; other locales fall back to English until translated.
- This branch and #57 both touch `user_jobs.go` in different spots; whichever merges first, the other should 3-way merge cleanly (keep both changes in the job-summary area if flagged).

Closes #49.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR introduces hybrid job naming for automatically created backend/frontend jobs so completed jobs are easier to पहचान by hashlist and preset, while keeping custom jobs and the programmatic jobs API behavior unchanged. It also updates the shared jobs table UI to surface the preset alongside the hashlist and makes the hashlist entry navigable.

- **Backend**
  - Added `preset_job_name` to `JobSummary` and populated it from the existing `preset_jobs` join, avoiding an extra query.
  - Extended job creation naming logic so preset/workflow jobs use `Client-Hashlist-Preset` naming when a client name is available; custom jobs still use the existing attack-config naming path.
  - Updated `/api/v1/jobs`-related summaries to include the preset name while preserving user-supplied naming for the programmatic endpoint.
  - **API/contract change:** job summary payloads now include `preset_job_name`.

- **Frontend**
  - Renamed the Jobs/Dashboard table column from **Hashlist** to **Hashlist / Preset**.
  - Made the hashlist name link to the hashlist page.
  - Displayed the preset name beneath the hashlist, or `N/A` for custom jobs.
  - Added `preset_job_name` to the frontend job summary type.

- **Docs**
  - Updated the English dashboard locale text for the renamed column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->