### PR TITLE
fix(backend,frontend): scope hashlist client picker to teams + enforce client access

### DIFF
--- a/backend/internal/handlers/api/v1/hashlist_handler.go
+++ b/backend/internal/handlers/api/v1/hashlist_handler.go
@@ -11,9 +11,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ZerkerEOD/krakenhashes/backend/internal/middleware"
 	"github.com/ZerkerEOD/krakenhashes/backend/internal/models"
 	"github.com/ZerkerEOD/krakenhashes/backend/internal/processor"
 	"github.com/ZerkerEOD/krakenhashes/backend/internal/repository"
+	"github.com/ZerkerEOD/krakenhashes/backend/internal/services"
 	"github.com/ZerkerEOD/krakenhashes/backend/pkg/debug"
 	"github.com/ZerkerEOD/krakenhashes/backend/pkg/httputil"
 	"github.com/google/uuid"
@@ -27,6 +29,7 @@ type HashlistHandler struct {
 	hashTypeRepo       *repository.HashTypeRepository
 	systemSettingsRepo *repository.SystemSettingsRepository
 	processor          *processor.HashlistDBProcessor
+	teamService        *services.TeamService
 	dataDir            string
 }
 
@@ -38,6 +41,7 @@ func NewHashlistHandler(
 	systemSettingsRepo *repository.SystemSettingsRepository,
 	processor *processor.HashlistDBProcessor,
 	dataDir string,
+	teamService *services.TeamService,
 ) *HashlistHandler {
 	return &HashlistHandler{
 		hashlistRepo:       hashlistRepo,
@@ -45,6 +49,7 @@ func NewHashlistHandler(
 		hashTypeRepo:       hashTypeRepo,
 		systemSettingsRepo: systemSettingsRepo,
 		processor:          processor,
+		teamService:        teamService,
 		dataDir:            dataDir,
 	}
 }
@@ -120,8 +125,26 @@ func (h *HashlistHandler) CreateHashlist(w http.ResponseWriter, r *http.Request)
 			sendError(w, "Client not found", "RESOURCE_NOT_FOUND", http.StatusNotFound)
 			return
 		}
+
+		// Verify the caller can access this client when teams are enabled
+		// (server-side defense — never trust the client_id supplied by the API
+		// caller). CanUserAccessClient is a no-op when teams are disabled or the
+		// caller is an admin.
+		if h.teamService != nil {
+			isAdmin := middleware.IsAdminFromContext(ctx)
+			canAccess, accessErr := h.teamService.CanUserAccessClient(ctx, userID, clientID, isAdmin)
+			if accessErr != nil {
+				debug.Error("Error checking client access for user %s, client %s: %v", userID.String(), clientID.String(), accessErr)
+				sendError(w, "Failed to verify client access", "INTERNAL_ERROR", http.StatusInternalServerError)
+				return
+			}
+			if !canAccess {
+				debug.Warning("User %s attempted to create hashlist for inaccessible client %s", userID.String(), clientID.String())
+				sendError(w, "You do not have access to this client", "ACCESS_DENIED", http.StatusForbidden)
+				return
+			}
+		}
 	}
-	// Note: Clients are global (no user ownership), all authenticated users can use any client
 
 	// Parse and validate hash_type_id
 	hashTypeID, err := strconv.Atoi(hashTypeIDStr)

--- a/backend/internal/middleware/user_api_middleware.go
+++ b/backend/internal/middleware/user_api_middleware.go
@@ -38,9 +38,19 @@ func UserAPIKeyMiddleware(userAPIService *services.UserAPIService) func(http.Han
 				return
 			}
 
-			// Store user ID in context for handlers
+			// Look up the user's role so team-aware handlers can honor the admin
+			// bypass (mirrors the web auth middleware). A lookup failure is
+			// non-fatal — default to an empty role, which fails closed (non-admin).
+			role, roleErr := userAPIService.GetUserRole(r.Context(), userID)
+			if roleErr != nil {
+				debug.Warning("Failed to load role for user %s: %v", userID.String(), roleErr)
+				role = ""
+			}
+
+			// Store user ID and role in context for handlers
 			ctx := context.WithValue(r.Context(), "user_id", userID.String())
 			ctx = context.WithValue(ctx, "user_uuid", userID)
+			ctx = context.WithValue(ctx, "user_role", role)
 			r = r.WithContext(ctx)
 
 			debug.Info("User API key authentication successful for user %s", userID.String())

--- a/backend/internal/routes/api_v1.go
+++ b/backend/internal/routes/api_v1.go
@@ -75,7 +75,7 @@ func SetupV1Routes(r *mux.Router, database *db.DB, dataDir string, binaryManager
 	v1Router.HandleFunc("/clients/{id}", clientHandler.DeleteClient).Methods("DELETE", "OPTIONS")
 
 	// Hashlist endpoints
-	hashlistHandler := v1handlers.NewHashlistHandler(hashlistRepo, clientRepo, hashTypeRepo, systemSettingsRepo, hashlistProcessor, hashlistDataDir)
+	hashlistHandler := v1handlers.NewHashlistHandler(hashlistRepo, clientRepo, hashTypeRepo, systemSettingsRepo, hashlistProcessor, hashlistDataDir, teamService)
 	v1Router.HandleFunc("/hashlists", hashlistHandler.CreateHashlist).Methods("POST", "OPTIONS")
 	v1Router.HandleFunc("/hashlists", hashlistHandler.ListHashlists).Methods("GET", "OPTIONS")
 	v1Router.HandleFunc("/hashlists/{id:[0-9]+}", hashlistHandler.GetHashlist).Methods("GET", "OPTIONS")

--- a/backend/internal/routes/hashlist.go
+++ b/backend/internal/routes/hashlist.go
@@ -1534,13 +1534,11 @@ func (h *hashlistHandler) handleGetProcessingProgress(w http.ResponseWriter, r *
 
 func (h *hashlistHandler) handleUpdateHashlistClient(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	_, err := getUserIDFromContext(ctx)
+	userID, err := getUserIDFromContext(ctx)
 	if err != nil {
 		jsonError(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
-	// Note: All authenticated users can update hashlist clients
-	// This will change when teams are implemented
 
 	id, err := getInt64FromPath(r, "id")
 	if err != nil {
@@ -1591,6 +1589,47 @@ func (h *hashlistHandler) handleUpdateHashlistClient(w http.ResponseWriter, r *h
 			jsonError(w, "Failed to retrieve hashlist", http.StatusInternalServerError)
 		}
 		return
+	}
+
+	// Verify team-based access when teams are enabled (server-side defense —
+	// never trust the client_id the caller supplied). No-op when teams are
+	// disabled or the caller is an admin.
+	if middleware.IsTeamsEnabledFromContext(ctx) && !middleware.IsAdminFromContext(ctx) {
+		// The user must be able to access the hashlist being modified (via its
+		// current client). Hashlists with no client fall back to ownership.
+		if hashlist.ClientID != uuid.Nil {
+			canAccess, accessErr := h.teamService.CanUserAccessClient(ctx, userID, hashlist.ClientID, false)
+			if accessErr != nil {
+				debug.Error("Error checking hashlist access for user %s, hashlist %d: %v", userID, id, accessErr)
+				jsonError(w, "Failed to verify hashlist access", http.StatusInternalServerError)
+				return
+			}
+			if !canAccess {
+				debug.Warning("User %s attempted to reassign inaccessible hashlist %d", userID, id)
+				jsonError(w, "You do not have access to this hashlist", http.StatusForbidden)
+				return
+			}
+		} else if hashlist.UserID != userID {
+			debug.Warning("User %s attempted to reassign hashlist %d owned by %s", userID, id, hashlist.UserID)
+			jsonError(w, "You do not have access to this hashlist", http.StatusForbidden)
+			return
+		}
+
+		// The user must be able to access the client the hashlist is being
+		// assigned to.
+		if clientID != uuid.Nil {
+			canAccess, accessErr := h.teamService.CanUserAccessClient(ctx, userID, clientID, false)
+			if accessErr != nil {
+				debug.Error("Error checking client access for user %s, client %s: %v", userID, clientID, accessErr)
+				jsonError(w, "Failed to verify client access", http.StatusInternalServerError)
+				return
+			}
+			if !canAccess {
+				debug.Warning("User %s attempted to reassign hashlist %d to inaccessible client %s", userID, id, clientID)
+				jsonError(w, "You do not have access to this client", http.StatusForbidden)
+				return
+			}
+		}
 	}
 
 	// Update the client

--- a/backend/internal/services/user_api_service.go
+++ b/backend/internal/services/user_api_service.go
@@ -102,6 +102,20 @@ func (s *UserAPIService) ValidateAPIKey(ctx context.Context, email, apiKey strin
 	return user.ID, nil
 }
 
+// GetUserRole returns a user's role. Used by the API-key middleware to populate
+// the request context so team-aware handlers can honor the admin bypass (the
+// API-key auth path has no session role like the web auth middleware does).
+func (s *UserAPIService) GetUserRole(ctx context.Context, userID uuid.UUID) (string, error) {
+	user, err := s.userRepo.GetByID(ctx, userID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get user: %w", err)
+	}
+	if user == nil {
+		return "", fmt.Errorf("user not found")
+	}
+	return user.Role, nil
+}
+
 // RevokeAPIKey revokes (nullifies) the API key for a user
 func (s *UserAPIService) RevokeAPIKey(ctx context.Context, userID uuid.UUID) error {
 	debug.Info("Revoking API key for user %s", userID.String())

--- a/frontend/src/components/hashlist/ClientAutocomplete.tsx
+++ b/frontend/src/components/hashlist/ClientAutocomplete.tsx
@@ -10,10 +10,15 @@ import {
   Checkbox,
   Collapse,
   Divider,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
 } from '@mui/material';
 import { Add as AddIcon } from '@mui/icons-material';
 import { listClients } from '../../services/api';
 import { Client } from '../../types/client';
+import { Team } from '../../types/team';
 
 // Option type for the Autocomplete dropdown
 interface ClientOption {
@@ -36,12 +41,19 @@ export interface NewClientData {
   dataRetentionMonths?: number | null;
   excludeFromPotfile?: boolean;
   excludeFromClientPotfile?: boolean;
+  // Team to file the new client under. Only meaningful when the user belongs
+  // to more than one team (existing clients derive their team from client_teams).
+  teamId?: string;
 }
 
 interface ClientAutocompleteProps {
   value: string | null;
   onChange: (clientName: string | null) => void;
-  teamId?: string;
+  // The user's teams. When creating a NEW client and the user belongs to more
+  // than one team, a required Team picker is shown so the client is filed under
+  // the intended team. Not used for selecting existing clients — the client list
+  // is already scoped to the user's teams server-side.
+  teams?: Team[];
   defaultRetention?: number | null;
   onNewClientDataChange?: (data: NewClientData | null) => void;
 }
@@ -49,7 +61,7 @@ interface ClientAutocompleteProps {
 export default function ClientAutocomplete({
   value,
   onChange,
-  teamId,
+  teams,
   defaultRetention,
   onNewClientDataChange,
 }: ClientAutocompleteProps) {
@@ -66,11 +78,13 @@ export default function ClientAutocomplete({
   const [newClientRetention, setNewClientRetention] = useState<string>('');
   const [newClientExcludePotfile, setNewClientExcludePotfile] = useState(false);
   const [newClientExcludeClientPotfile, setNewClientExcludeClientPotfile] = useState(false);
+  const [newClientTeamId, setNewClientTeamId] = useState<string>('');
 
-  // Fetch clients on mount and when teamId changes
+  // Fetch clients on mount. The list is already scoped to the user's teams
+  // server-side (GET /api/clients), so no client-side team filtering is needed.
   useEffect(() => {
     fetchClients();
-  }, [teamId]);
+  }, []);
 
   const fetchClients = async () => {
     setLoading(true);
@@ -79,9 +93,6 @@ export default function ClientAutocomplete({
       const response = await listClients();
       let clients: Client[] = response.data?.data || [];
 
-      // Filter by team if teamId is provided (client-side filter for team-scoped view)
-      // The backend listClients returns all accessible clients; team filtering
-      // is typically handled by backend middleware, but we add client-side filter as safety
       const clientOptions: ClientOption[] = clients.map((c) => ({
         id: c.id,
         name: c.name,
@@ -132,6 +143,7 @@ export default function ClientAutocomplete({
           : undefined,
         excludeFromPotfile: newClientExcludePotfile,
         excludeFromClientPotfile: newClientExcludeClientPotfile,
+        teamId: newClientTeamId || undefined,
       });
     } else if (isCreateMode) {
       onNewClientDataChange?.(null);
@@ -144,6 +156,7 @@ export default function ClientAutocomplete({
     newClientRetention,
     newClientExcludePotfile,
     newClientExcludeClientPotfile,
+    newClientTeamId,
   ]);
 
   const handleOptionChange = (_event: React.SyntheticEvent, newValue: ClientOption | null) => {
@@ -156,6 +169,9 @@ export default function ClientAutocomplete({
       setNewClientRetention('');
       setNewClientExcludePotfile(false);
       setNewClientExcludeClientPotfile(false);
+      // Default to the sole team when the user has exactly one; otherwise force
+      // an explicit choice (empty) so a multi-team user can't silently misfile.
+      setNewClientTeamId(teams && teams.length === 1 ? teams[0].id : '');
       onChange(null); // Clear until user types a name
     } else {
       setSelectedOption(newValue);
@@ -224,6 +240,29 @@ export default function ClientAutocomplete({
             New Client Details
           </Typography>
           <Divider sx={{ mb: 2 }} />
+
+          {/* Team picker — only needed when the user belongs to more than one
+              team, so the new client is filed under the intended team. */}
+          {teams && teams.length > 1 && (
+            <FormControl fullWidth required={isCreateMode} sx={{ mb: 2 }}>
+              <InputLabel id="new-client-team-label">Team</InputLabel>
+              <Select
+                labelId="new-client-team-label"
+                value={newClientTeamId}
+                label="Team"
+                onChange={(e) => setNewClientTeamId(e.target.value)}
+              >
+                {teams.map((team) => (
+                  <MenuItem key={team.id} value={team.id}>
+                    {team.name}
+                  </MenuItem>
+                ))}
+              </Select>
+              <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, ml: 1.75 }}>
+                The new client will be assigned to this team.
+              </Typography>
+            </FormControl>
+          )}
 
           <TextField
             fullWidth

--- a/frontend/src/components/hashlist/HashlistUploadForm.tsx
+++ b/frontend/src/components/hashlist/HashlistUploadForm.tsx
@@ -16,10 +16,6 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
 } from '@mui/material';
 import { Clear as ClearIcon } from '@mui/icons-material';
 import ClientAutocomplete, { NewClientData } from './ClientAutocomplete';
@@ -82,9 +78,7 @@ export default function HashlistUploadForm({ onSuccess }: HashlistUploadFormProp
   const [potfileGloballyEnabled, setPotfileGloballyEnabled] = useState(true);
   const [clientPotfilesSystemEnabled, setClientPotfilesSystemEnabled] = useState(true);
   const [requireClient, setRequireClient] = useState(false);
-  const [teamsEnabled, setTeamsEnabled] = useState(false);
   const [userTeams, setUserTeams] = useState<Team[]>([]);
-  const [selectedTeamId, setSelectedTeamId] = useState<string>('');
   const [detectionResult, setDetectionResult] = useState<any>(null);
   const [showLinkDialog, setShowLinkDialog] = useState(false);
   const [isDetecting, setIsDetecting] = useState(false);
@@ -108,7 +102,7 @@ export default function HashlistUploadForm({ onSuccess }: HashlistUploadFormProp
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
-  const { control, handleSubmit, reset, setValue, formState: { errors } } = useForm<FormData>({
+  const { control, handleSubmit, reset, formState: { errors } } = useForm<FormData>({
     resolver: zodResolver(createSchema(requireClient)),
     defaultValues: {
       name: '',
@@ -221,15 +215,11 @@ export default function HashlistUploadForm({ onSuccess }: HashlistUploadFormProp
         if (teamsEnabled) {
           // If teams are enabled, client is always required
           setRequireClient(true);
-          setTeamsEnabled(true);
-          // Fetch user's teams for the team selector
+          // Fetch the user's teams so a NEW client can be filed under the
+          // right team (only prompted when the user belongs to >1 team).
           try {
             const teams = await teamsService.listUserTeams();
             setUserTeams(teams);
-            // Auto-select if user has exactly one team
-            if (teams.length === 1) {
-              setSelectedTeamId(teams[0].id);
-            }
           } catch (teamErr) {
             console.error('Failed to fetch user teams:', teamErr);
           }
@@ -297,12 +287,14 @@ export default function HashlistUploadForm({ onSuccess }: HashlistUploadFormProp
       if (createLinked) {
         formData.append('create_linked', 'true');
       }
-      if (selectedTeamId) {
-        formData.append('team_id', selectedTeamId);
-      }
 
       // Append new client override fields when creating a new client
       if (newClientData) {
+        // Only a NEW client needs an explicit team — existing clients derive
+        // their team from client_teams server-side.
+        if (newClientData.teamId) {
+          formData.append('team_id', newClientData.teamId);
+        }
         if (newClientData.description) {
           formData.append('client_description', newClientData.description);
         }
@@ -389,6 +381,12 @@ export default function HashlistUploadForm({ onSuccess }: HashlistUploadFormProp
   });
 
   const onSubmit = (data: FormData): void => {
+    // Creating a new client while the user belongs to more than one team
+    // requires an explicit team so it isn't silently filed under the wrong one.
+    if (newClientData && userTeams.length > 1 && !newClientData.teamId) {
+      enqueueSnackbar('Please select a team for the new client.', { variant: 'error' });
+      return;
+    }
     uploadMutation.mutate(data);
   };
 
@@ -437,29 +435,6 @@ export default function HashlistUploadForm({ onSuccess }: HashlistUploadFormProp
         )}
       />
 
-      {/* Team Selector — shown when teams enabled and user has multiple teams */}
-      {teamsEnabled && userTeams.length > 1 && (
-        <FormControl fullWidth margin="normal">
-          <InputLabel id="team-select-label">Team</InputLabel>
-          <Select
-            labelId="team-select-label"
-            value={selectedTeamId}
-            label="Team"
-            onChange={(e) => {
-              setSelectedTeamId(e.target.value);
-              // Clear client when team changes (clients are team-scoped)
-              setValue('clientName', null);
-            }}
-          >
-            {userTeams.map((team) => (
-              <MenuItem key={team.id} value={team.id}>
-                {team.name}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      )}
-
       <Controller
         name="clientName"
         control={control}
@@ -468,7 +443,7 @@ export default function HashlistUploadForm({ onSuccess }: HashlistUploadFormProp
             <ClientAutocomplete
               value={field.value ?? null}
               onChange={field.onChange}
-              teamId={selectedTeamId || undefined}
+              teams={userTeams}
               defaultRetention={defaultRetention}
               onNewClientDataChange={setNewClientData}
             />


### PR DESCRIPTION
## Summary

When teams are enabled, the hashlist upload form let a user pair a selected **team** with a **client from a different team**, and two hashlist write paths trusted the caller-supplied `client_id` without verifying team access. This removes the redundant team selector and enforces client access **server-side**.

Hashlists are only ever linked to a **client** (no `team_id` column); a client's team membership (`client_teams`) already governs access, so the standalone team picker was redundant for existing clients and only genuinely matters when *creating a new client* while a user belongs to more than one team.

## Frontend

- **HashlistUploadForm**: remove the standalone Team `<Select>`. The client list is already scoped to the user's teams server-side (`GET /api/clients`), so team choice only matters when creating a new client. `team_id` is now sent **only** for new-client creation, and submit is blocked if a multi-team user creates a new client without picking a team.
- **ClientAutocomplete**: drop the unused `teamId` prop and its dead "client-side filter" comment; render a required **Team** picker inside the "Create New Client" sub-form **only when the user is in >1 team**.

## Backend (all no-ops when teams are disabled or the caller is an admin)

- **`routes/hashlist.go` → `handleUpdateHashlistClient`** (`PATCH /api/hashlists/{id}/client`): previously had *no* access check (self-admitted TODO). Now verifies the user can access **both** the hashlist (via its current client, owner-fallback when none) **and** the target client before reassigning.
- **`handlers/api/v1/hashlist_handler.go` → `CreateHashlist`** (`POST /api/v1/hashlists`): accepted a raw `client_id` with no team check. Now runs `TeamService.CanUserAccessClient`; `TeamService` is injected and wired in `api_v1.go`.
- **`middleware/user_api_middleware.go` + `services/user_api_service.go`**: populate the user's role into the API-key request context (new `GetUserRole`) so team-aware handlers honor the admin bypass (the API-key path previously had no role in context).

## Notes / Compatibility

- No DB migrations. Hashlists remain client-only.
- Non-teams deployments are unaffected — every new guard short-circuits to allow when teams are disabled or the caller is an admin.

## Testing

Not built/run locally (builds are done manually per repo workflow). TypeScript diagnostics are clean on the changed frontend files. Suggested manual verification:

**Teams enabled**, normal user in two teams:
1. Upload form shows **no** team selector; client dropdown lists only that user's team clients.
2. "Create New Client" shows a required team picker (2+ teams); the new client is filed under the chosen team (`client_teams` row).
3. `PATCH /api/hashlists/{id}/client` and `POST /api/v1/hashlists` with a `client_id` outside the user's teams → **403**; a client in-team → succeeds.

**Teams disabled**: no team UI; all three paths behave exactly as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR scopes hashlist client selection to team access and adds server-side authorization for hashlist write operations. It also updates the client creation flow to collect team selection only when needed, and propagates user role information through API-key requests to support admin bypass. No database migrations were added. API/contract changes include updated handler/service signatures and a request-context `user_role` value; the removed standalone team selector and changed client picker props are breaking frontend contract changes.

- **Backend**
  - Enforces client access when creating hashlists (`POST /api/v1/hashlists`) via `TeamService.CanUserAccessClient`.
  - Enforces access on hashlist client reassignment (`PATCH /api/hashlists/{id}/client`) for both the existing hashlist and target client.
  - Adds `GetUserRole` and stores `user_role` in API-key request context to support admin bypass.
  - Wires the hashlist handler with `teamService` and `hashlistDataDir`.

- **Frontend**
  - Removes the standalone Team selector from `HashlistUploadForm`.
  - Sends `team_id` only when creating a new client.
  - Updates `ClientAutocomplete` to accept `teams` instead of `teamId` and show a required team picker only for users with multiple teams.
  - Simplifies client loading behavior and keeps new-client team selection inside the autocomplete form.

- **Docs**
  - No documentation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->