### PR TITLE
fix: chunk progress display + premature completion (#62), scheduler readiness gate + orphan-task guard

### DIFF
--- a/agent/internal/agent/connection.go
+++ b/agent/internal/agent/connection.go
@@ -2580,6 +2580,14 @@ func (c *Connection) createAgentStatusMessage() (*WSMessage, error) {
 		"status":     "active",
 		"version":    version.GetVersion(),
 		"updated_at": time.Now(),
+		// file_map_ready surfaces the agent's startup MD5-map readiness so the
+		// scheduler-v2 dispatcher can avoid handing tasks to an agent that would
+		// only reject them (which the backend would then record as failed rows,
+		// GH #61). Sent on every agent_status (initial + periodic + on-flip), so
+		// it self-heals across a backend restart and re-establishes on reconnect.
+		// An older agent simply omits this key; the backend treats absence as
+		// "ready" (fail-open) so this never gates existing agents out.
+		"file_map_ready": c.fileMapReady(),
 		"environment": map[string]string{
 			"os":       runtime.GOOS,
 			"arch":     runtime.GOARCH,
@@ -3038,6 +3046,39 @@ func (c *Connection) initializeFileSync(apiKey, agentID string) error {
 func (c *Connection) markFileMapReady() {
 	if jm, ok := c.jobManager.(*jobs.JobManager); ok {
 		jm.MarkFileMapReady()
+	}
+	// Push an agent_status immediately so the backend learns readiness now
+	// rather than up to a full status-ticker interval later — otherwise the
+	// agent sits idle for as much as a minute after its map is built (GH #61).
+	// The periodic ticker keeps re-reporting it for self-healing.
+	c.sendAgentStatusUpdate()
+}
+
+// fileMapReady reports whether the job manager has finished building its
+// startup MD5 map. Reported to the backend on every agent_status so the
+// scheduler can gate dispatch (GH #61). Returns true when the job manager
+// isn't a *jobs.JobManager (e.g. not yet wired) — there is no map to gate on,
+// so fail open rather than pinning the agent as perpetually not-ready.
+func (c *Connection) fileMapReady() bool {
+	if jm, ok := c.jobManager.(*jobs.JobManager); ok {
+		return jm.FileMapReady()
+	}
+	return true
+}
+
+// sendAgentStatusUpdate builds and queues an agent_status message immediately,
+// outside the periodic status ticker. Used to promptly surface a readiness
+// change (file_map_ready) to the backend. Best-effort: logs and returns on any
+// failure. safeSendMessage drops the message if the outbound channel is closed,
+// so this is safe to call regardless of connection state.
+func (c *Connection) sendAgentStatusUpdate() {
+	statusMsg, err := c.createAgentStatusMessage()
+	if err != nil {
+		debug.Error("Failed to create agent status update: %v", err)
+		return
+	}
+	if !c.safeSendMessage(statusMsg, 1000) {
+		debug.Warning("Failed to queue agent status update (channel blocked or closed)")
 	}
 }
 

--- a/agent/internal/jobs/hashcat_executor.go
+++ b/agent/internal/jobs/hashcat_executor.go
@@ -1356,13 +1356,15 @@ func (e *HashcatExecutor) runHashcatProcess(ctx context.Context, process *Hashca
 							}
 						}
 
-						// When hashcat reports status code 6 (all hashes cracked),
-						// mark task as completed immediately
-						status := "running"
-						if progress.AllHashesCracked {
-							status = "completed"
-						}
-						e.sendProgressUpdate(process, progress, status)
+						// Streaming status updates are always sent as "running".
+						// Even when hashcat reports status code 6 (all hashes
+						// cracked), the task is NOT completed until the hashcat
+						// process actually exits — the AllHashesCracked flag is
+						// still propagated so the backend can trigger
+						// hashlist-completion handling and 100% display, but the
+						// real "completed" status is emitted from the process-exit
+						// handler below.
+						e.sendProgressUpdate(process, progress, "running")
 						// Update last progress and checkpoint on the process
 						process.LastProgress = progress
 						process.LastCheckpoint = time.Now()

--- a/backend/internal/handlers/jobs/user_jobs.go
+++ b/backend/internal/handlers/jobs/user_jobs.go
@@ -1337,6 +1337,7 @@ func (h *UserJobsHandler) GetJobDetail(w http.ResponseWriter, r *http.Request) {
 			"retry_count":                  task.RetryCount,
 			"detailed_status":              task.DetailedStatus,
 			"error_message":                task.ErrorMessage,
+			"failure_reason":               task.FailureReason,
 			"created_at":                   task.CreatedAt.Format(time.RFC3339),
 		}
 

--- a/backend/internal/handlers/websocket/handler.go
+++ b/backend/internal/handlers/websocket/handler.go
@@ -128,6 +128,16 @@ type Handler struct {
 	// "currently running" state doesn't loop into a rejection storm.
 	// Keys are agentID (int); values are time.Time.
 	recentRejections sync.Map
+
+	// fileMapReady tracks the last-known startup-file-map readiness each agent
+	// reported on its periodic agent_status message (GH #61). Keys are agentID
+	// (int); values are bool. ABSENCE of a key means "unknown" and is treated
+	// as READY (fail-open) by IsFileMapReady, so an older agent that never
+	// reports the field — or one whose first status hasn't arrived yet — stays
+	// dispatch-eligible, mirroring the absence-of-bad-signal semantics of
+	// recentRejections/shuttingDown. Only an explicit false gates dispatch.
+	// The entry is cleared on disconnect so a fresh connection must re-report.
+	fileMapReady sync.Map
 }
 
 // Client represents a connected agent
@@ -499,6 +509,9 @@ func (c *Client) readPump() {
 		case wsservice.TypeAgentShutdown:
 			c.handler.handleAgentShutdown(c, &msg)
 
+		case wsservice.TypeAgentStatus:
+			c.handler.handleAgentStatusReadiness(c, &msg)
+
 		case wsservice.TypeTaskAssignmentRejected:
 			c.handler.handleTaskAssignmentRejected(c, &msg)
 
@@ -680,6 +693,11 @@ func (h *Handler) unregisterClient(c *Client) {
 	if client, ok := h.clients[c.agent.ID]; ok {
 		if client == c {
 			delete(h.clients, c.agent.ID)
+			// Forget file-map readiness only when removing the CURRENT
+			// connection, so a stale readPump's teardown can't wipe the state
+			// a newer connection just reported. A fresh connection then starts
+			// clean and must re-report before it can be gated (GH #61).
+			h.fileMapReady.Delete(c.agent.ID)
 		}
 	}
 	h.mu.Unlock()
@@ -807,6 +825,55 @@ func (h *Handler) WasRecentlyRejected(agentID int) bool {
 		return false
 	}
 	return true
+}
+
+// handleAgentStatusReadiness records the agent's startup-file-map readiness
+// (GH #61) from its periodic agent_status message. The full status (DB
+// status/version/OS info) is processed separately in the service layer
+// (websocket.Service.handleAgentStatus); here we only extract file_map_ready
+// so the scheduler-v2 cycle can gate dispatch on it via IsFileMapReady.
+//
+// file_map_ready is a pointer on the wire: nil means the agent didn't report it
+// (an older agent version, or a status emitted before the field existed). We
+// only store an explicit value, so a nil field never flips an agent to
+// not-ready — preserving fail-open dispatch for agents that never report.
+func (h *Handler) handleAgentStatusReadiness(client *Client, msg *wsservice.Message) {
+	var payload wsservice.AgentStatusPayload
+	if err := json.Unmarshal(msg.Payload, &payload); err != nil {
+		debug.Error("Agent %d: Failed to unmarshal agent status for readiness: %v", client.agent.ID, err)
+		return
+	}
+	if payload.FileMapReady == nil {
+		// Old agent / field absent — leave the last-known state untouched so
+		// absence never gates the agent out.
+		return
+	}
+	h.fileMapReady.Store(client.agent.ID, *payload.FileMapReady)
+	debug.Debug("Agent %d: reported file_map_ready=%t", client.agent.ID, *payload.FileMapReady)
+}
+
+// IsFileMapReady reports whether the agent is eligible for scheduler-v2
+// dispatch with respect to its startup file-map build (GH #61). It returns
+// true UNLESS the agent's last-known agent_status explicitly reported
+// file_map_ready=false.
+//
+// Fail-open by design, mirroring IsShuttingDown/WasRecentlyRejected: an agent
+// we have never heard a readiness signal from — an older agent that doesn't
+// send the field, or a freshly connected agent whose first status hasn't
+// arrived — is treated as READY so we don't regress dispatch for existing
+// deployments. Only an EXPLICIT not-ready report gates the agent out, and only
+// until it reports ready (or disconnects, which clears the entry).
+func (h *Handler) IsFileMapReady(agentID int) bool {
+	v, ok := h.fileMapReady.Load(agentID)
+	if !ok {
+		return true // unknown → fail open (eligible)
+	}
+	ready, ok := v.(bool)
+	if !ok {
+		h.fileMapReady.Delete(agentID)
+		return true
+	}
+	return ready
 }
 
 // sendInitialConfiguration sends initial configuration to the agent including download settings

--- a/backend/internal/integration/job_integration.go
+++ b/backend/internal/integration/job_integration.go
@@ -31,6 +31,7 @@ type JobIntegrationManager struct {
 		GetConnectedAgents() []int
 		IsShuttingDown(agentID int) bool
 		WasRecentlyRejected(agentID int) bool
+		IsFileMapReady(agentID int) bool
 		MarkRejected(agentID int)
 		RegisterInventoryCallback(agentID int) <-chan *wsservice.FileSyncResponsePayload
 		UnregisterInventoryCallback(agentID int)
@@ -79,6 +80,7 @@ func NewJobIntegrationManager(
 		GetConnectedAgents() []int
 		IsShuttingDown(agentID int) bool
 		WasRecentlyRejected(agentID int) bool
+		IsFileMapReady(agentID int) bool
 		MarkRejected(agentID int)
 		RegisterInventoryCallback(agentID int) <-chan *wsservice.FileSyncResponsePayload
 		UnregisterInventoryCallback(agentID int)

--- a/backend/internal/integration/job_websocket_integration.go
+++ b/backend/internal/integration/job_websocket_integration.go
@@ -2023,67 +2023,14 @@ func (s *JobWebSocketIntegration) HandleJobProgress(ctx context.Context, agentID
 		}
 	}
 
-	// Check if task is complete based on keyspace
-	// KeyspaceProcessed is the restore_point from hashcat, which is ABSOLUTE (not relative to KeyspaceStart)
-	// Compare against KeyspaceEnd directly, not (KeyspaceEnd - KeyspaceStart)
-	if task.KeyspaceEnd > 0 && progress.KeyspaceProcessed >= task.KeyspaceEnd {
-		// Keyspace complete - but if there are cracks, wait for crack_batches_complete
-		// to ensure all cracks are confirmed in the database before marking complete
-		if progress.CrackedCount > 0 {
-			// Set to processing status - will be completed when crack_batches_complete is received
-			// and all cracks are verified in the database
-			err = s.jobTaskRepo.SetTaskProcessing(ctx, progress.TaskID, progress.CrackedCount)
-			if err != nil {
-				debug.Error("Failed to set task to processing status: %v", err)
-			} else {
-				debug.Info("Task %s keyspace complete with %d cracks - set to processing, waiting for crack_batches_complete",
-					progress.TaskID, progress.CrackedCount)
-			}
-			// Don't complete yet - HandleCrackBatchesComplete will complete the task
-			// after verifying all cracks are in the database
-			return nil
-		}
-
-		// No cracks - can complete immediately since there's nothing to verify
-		debug.Info("Task %s keyspace complete with 0 cracks - completing immediately", progress.TaskID)
-
-		// Mark task as complete AND clear agent busy status atomically
-		if task.AgentID != nil {
-			err = s.jobTaskRepo.CompleteTaskAndClearAgentStatus(ctx, progress.TaskID, *task.AgentID)
-			if err != nil {
-				debug.Error("Failed to atomically complete task and clear agent status (keyspace): %v", err)
-			}
-		} else {
-			// No agent ID - just complete the task
-			err = s.jobTaskRepo.CompleteTask(ctx, progress.TaskID)
-			if err != nil {
-				debug.Error("Failed to mark task as complete: %v", err)
-			}
-		}
-
-		// Handle task completion cleanup
-		err = s.jobExecutionService.HandleTaskCompletion(ctx, progress.TaskID)
-		if err != nil {
-			debug.Log("Failed to handle task completion", map[string]interface{}{
-				"task_id": progress.TaskID,
-				"error":   err.Error(),
-			})
-		}
-
-		// Check if job is complete
-		err = s.jobSchedulingService.ProcessJobCompletion(ctx, task.JobExecutionID)
-		if err != nil {
-			debug.Log("Failed to process job completion", map[string]interface{}{
-				"job_execution_id": task.JobExecutionID,
-				"error":            err.Error(),
-			})
-		}
-
-		// Cache completion and send ACK to agent (GH Issue #12)
-		taskIDStr := progress.TaskID.String()
-		s.cacheCompletion(taskIDStr)
-		s.sendTaskCompleteAck(agentID, taskIDStr, true, "")
-	}
+	// GH #62: The former "task complete based on keyspace" auto-completion
+	// block was removed here. In distributed (keyspace-split) jobs with slow
+	// salted/rule modes, the reported/estimated keyspace could cross the
+	// chunk's estimated boundary while hashcat was still running, causing the
+	// task (and job) to complete prematurely and freezing the displayed
+	// percent at 100. Completion now flows ONLY through the explicit
+	// progress.Status == "completed" handler (hashcat exit) earlier in this
+	// function and the all-cracked (code-6) path.
 
 	return nil
 }

--- a/backend/internal/models/jobs.go
+++ b/backend/internal/models/jobs.go
@@ -320,6 +320,7 @@ type JobTask struct {
 	UpdatedAt           time.Time     `json:"updated_at" db:"updated_at"`
 	LastCheckpoint      *time.Time    `json:"last_checkpoint" db:"last_checkpoint"`
 	ErrorMessage        *string       `json:"error_message" db:"error_message"`
+	FailureReason       *string       `json:"failure_reason,omitempty" db:"failure_reason"` // Populated by scheduler recovery/sweeper when a task is marked terminal; surfaced to the UI
 
 	// Enhanced fields for detailed chunk tracking
 	CrackCount              int  `json:"crack_count" db:"crack_count"`

--- a/backend/internal/repository/job_task_repository.go
+++ b/backend/internal/repository/job_task_repository.go
@@ -274,6 +274,7 @@ func (r *JobTaskRepository) GetByID(ctx context.Context, id uuid.UUID) (*models.
 			jt.effective_keyspace_start, jt.effective_keyspace_end, jt.effective_keyspace_processed,
 			jt.benchmark_speed, jt.average_speed, jt.chunk_duration, jt.assigned_at,
 			jt.started_at, jt.completed_at, jt.cracking_completed_at, jt.last_checkpoint, jt.error_message,
+			jt.failure_reason,
 			jt.crack_count, jt.detailed_status, jt.retry_count,
 			jt.expected_crack_count, jt.received_crack_count, jt.batches_complete_signaled,
 			jt.chunk_number, jt.is_actual_keyspace, jt.chunk_actual_keyspace, jt.is_keyspace_split,
@@ -293,6 +294,7 @@ func (r *JobTaskRepository) GetByID(ctx context.Context, id uuid.UUID) (*models.
 		&task.EffectiveKeyspaceStart, &task.EffectiveKeyspaceEnd, &task.EffectiveKeyspaceProcessed,
 		&task.BenchmarkSpeed, &task.AverageSpeed, &task.ChunkDuration, &task.AssignedAt,
 		&task.StartedAt, &task.CompletedAt, &task.CrackingCompletedAt, &task.LastCheckpoint, &task.ErrorMessage,
+		&task.FailureReason,
 		&task.CrackCount, &task.DetailedStatus, &task.RetryCount,
 		&task.ExpectedCrackCount, &task.ReceivedCrackCount, &task.BatchesCompleteSignaled,
 		&chunkNumber, &task.IsActualKeyspace, &task.ChunkActualKeyspace, &task.IsKeyspaceSplit,
@@ -321,6 +323,7 @@ func (r *JobTaskRepository) GetTasksByJobExecution(ctx context.Context, jobExecu
 			jt.effective_keyspace_start, jt.effective_keyspace_end, jt.effective_keyspace_processed,
 			jt.benchmark_speed, jt.average_speed, jt.chunk_duration, jt.assigned_at,
 			jt.started_at, jt.completed_at, jt.cracking_completed_at, jt.last_checkpoint, jt.error_message,
+			jt.failure_reason,
 			jt.crack_count,
 			jt.increment_layer_id,
 			jt.progress_percent,
@@ -345,6 +348,7 @@ func (r *JobTaskRepository) GetTasksByJobExecution(ctx context.Context, jobExecu
 			&task.EffectiveKeyspaceStart, &task.EffectiveKeyspaceEnd, &task.EffectiveKeyspaceProcessed,
 			&task.BenchmarkSpeed, &task.AverageSpeed, &task.ChunkDuration, &task.AssignedAt,
 			&task.StartedAt, &task.CompletedAt, &task.CrackingCompletedAt, &task.LastCheckpoint, &task.ErrorMessage,
+			&task.FailureReason,
 			&task.CrackCount,
 			&task.IncrementLayerID,
 			&task.ProgressPercent,
@@ -382,6 +386,7 @@ func (r *JobTaskRepository) GetTasksByJobExecutions(ctx context.Context, jobExec
 			jt.effective_keyspace_start, jt.effective_keyspace_end, jt.effective_keyspace_processed,
 			jt.benchmark_speed, jt.average_speed, jt.chunk_duration, jt.assigned_at,
 			jt.started_at, jt.completed_at, jt.cracking_completed_at, jt.last_checkpoint, jt.error_message,
+			jt.failure_reason,
 			jt.crack_count,
 			jt.increment_layer_id,
 			jt.progress_percent,
@@ -405,6 +410,7 @@ func (r *JobTaskRepository) GetTasksByJobExecutions(ctx context.Context, jobExec
 			&task.EffectiveKeyspaceStart, &task.EffectiveKeyspaceEnd, &task.EffectiveKeyspaceProcessed,
 			&task.BenchmarkSpeed, &task.AverageSpeed, &task.ChunkDuration, &task.AssignedAt,
 			&task.StartedAt, &task.CompletedAt, &task.CrackingCompletedAt, &task.LastCheckpoint, &task.ErrorMessage,
+			&task.FailureReason,
 			&task.CrackCount,
 			&task.IncrementLayerID,
 			&task.ProgressPercent,
@@ -775,13 +781,19 @@ func (r *JobTaskRepository) StartTask(ctx context.Context, id uuid.UUID) error {
 func (r *JobTaskRepository) UpdateProgress(ctx context.Context, id uuid.UUID, keyspaceProcessed int64, effectiveKeyspaceProcessed models.BigInt, benchmarkSpeed *int64, progressPercent float64) error {
 	now := time.Now()
 	// Monotonic-progress guard: reject UPDATEs that would decrease
-	// progress_percent or keyspace_processed. Real work is monotonic;
-	// any backward write is a buggy agent message (e.g., the empty
-	// 0%/0H/s message previously sent on Ctrl+C cancellation —
-	// Step 10c-1 fixed the agent, this guard prevents future
-	// regressions of the same class).
+	// keyspace_processed. Real work is monotonic; any backward write is
+	// a buggy agent message (e.g., the empty 0%/0H/s message previously
+	// sent on Ctrl+C cancellation — Step 10c-1 fixed the agent, this
+	// guard prevents future regressions of the same class).
 	//
-	// COALESCE so a row with NULL progress_percent (just dispatched,
+	// progress_percent is NO LONGER part of the monotonic guard: it is a
+	// derived display value recomputed from the chunk-local keyspace on
+	// every call (see UpdateTaskProgress Step 11r) and is capped below
+	// 100 for in-flight tasks. keyspace_processed remains the sole
+	// monotonic signal; guarding on it alone still rejects the buggy
+	// backward keyspace_processed=0 Ctrl+C message this guard exists for.
+	//
+	// COALESCE so a row with NULL keyspace_processed (just dispatched,
 	// no progress yet) accepts the first write.
 	//
 	// We do NOT return ErrNotFound when rowsAffected=0, because that
@@ -791,7 +803,6 @@ func (r *JobTaskRepository) UpdateProgress(ctx context.Context, id uuid.UUID, ke
 		UPDATE job_tasks
 		SET keyspace_processed = $1, effective_keyspace_processed = $2, benchmark_speed = $3, last_checkpoint = $4, progress_percent = $5
 		WHERE id = $6
-		  AND COALESCE(progress_percent, 0) <= $5
 		  AND COALESCE(keyspace_processed, 0) <= $1`
 
 	result, err := r.db.ExecContext(ctx, query, keyspaceProcessed, effectiveKeyspaceProcessed, benchmarkSpeed, now, progressPercent, id)
@@ -966,6 +977,73 @@ func (r *JobTaskRepository) CompleteTaskAndClearAgentStatus(ctx context.Context,
 	}
 
 	debug.Log("Atomically completed task and cleared agent status", map[string]interface{}{
+		"task_id":  taskID,
+		"agent_id": agentID,
+	})
+
+	return nil
+}
+
+// CancelTaskAndClearAgentStatus atomically marks a task as cancelled AND clears the agent's busy status.
+// Mirrors CompleteTaskAndClearAgentStatus but uses a 'cancelled' terminal state instead of 'completed'.
+// Used by the all-hashes-cracked flow to terminalize sibling tasks that are being stopped (GH #62):
+// the DB must NEVER be in state job=completed with a task still in {running,assigned,processing,pending}.
+// We deliberately do NOT force progress_percent=100 here — the chunk did not finish its keyspace; it was
+// stopped early because the hashlist is already fully cracked. 'cancelled' (NOT 'failed') is used so
+// HasFailedTasks does not flip the job to 'failed'.
+func (r *JobTaskRepository) CancelTaskAndClearAgentStatus(ctx context.Context, taskID uuid.UUID, agentID int) error {
+	// Begin transaction for atomicity
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	now := time.Now()
+
+	// Step 1: Mark task as cancelled (terminal)
+	taskQuery := `
+		UPDATE job_tasks
+		SET status = $1,
+		    detailed_status = $2,
+		    completed_at = $3
+		WHERE id = $4`
+
+	result, err := tx.ExecContext(ctx, taskQuery, models.JobTaskStatusCancelled, "cancelled", now, taskID)
+	if err != nil {
+		return fmt.Errorf("failed to cancel task: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected for task: %w", err)
+	}
+	if rowsAffected == 0 {
+		return ErrNotFound
+	}
+
+	// Step 2: Clear agent busy status atomically with task cancellation
+	// Use JSONB operators to update metadata
+	agentQuery := `
+		UPDATE agents
+		SET metadata = COALESCE(metadata, '{}'::jsonb)
+		              || '{"busy_status": "false"}'::jsonb
+		              - 'current_task_id'
+		              - 'current_job_id',
+		    updated_at = CURRENT_TIMESTAMP
+		WHERE id = $1`
+
+	_, err = tx.ExecContext(ctx, agentQuery, agentID)
+	if err != nil {
+		return fmt.Errorf("failed to clear agent busy status: %w", err)
+	}
+
+	// Commit the transaction
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	debug.Log("Atomically cancelled task and cleared agent status", map[string]interface{}{
 		"task_id":  taskID,
 		"agent_id": agentID,
 	})
@@ -1254,7 +1332,13 @@ func (r *JobTaskRepository) SetTaskStopping(ctx context.Context, id uuid.UUID) e
 }
 
 // ClearTaskAgentAndSetPending clears agent_id and sets task to pending after stop ack received
-// This should only be called after the agent has acknowledged stopping the task
+// This should only be called after the agent has acknowledged stopping the task.
+//
+// It must NOT resurrect a task whose recovery already finished: a stop-ack can arrive AFTER
+// the heartbeat sweeper's recovery marked a truncated/overrun chunk terminal ('completed',
+// 'cancelled' or 'failed'). The terminal-state guard in the WHERE clause makes that a safe
+// no-op (rowsAffected == 0) instead of clobbering the terminal row back to 'pending', which
+// would strand an orphaned pending-at-100% task that blocks job completion forever.
 func (r *JobTaskRepository) ClearTaskAgentAndSetPending(ctx context.Context, id uuid.UUID, agentID int) error {
 	query := `
 		UPDATE job_tasks
@@ -1266,7 +1350,8 @@ func (r *JobTaskRepository) ClearTaskAgentAndSetPending(ctx context.Context, id 
 			started_at = NULL,
 			last_checkpoint = CURRENT_TIMESTAMP,
 			updated_at = CURRENT_TIMESTAMP
-		WHERE id = $1 AND agent_id = $2`
+		WHERE id = $1 AND agent_id = $2
+		  AND status NOT IN ('completed', 'cancelled', 'failed')`
 
 	result, err := r.db.ExecContext(ctx, query, id, agentID)
 	if err != nil {

--- a/backend/internal/repository/job_task_repository_extension.go
+++ b/backend/internal/repository/job_task_repository_extension.go
@@ -19,6 +19,7 @@ func (r *JobTaskRepository) GetAllTasksByJobExecution(ctx context.Context, jobEx
 			COALESCE(detailed_status, 'pending') as detailed_status,
 			COALESCE(retry_count, 0) as retry_count,
 			error_message,
+			failure_reason,
 			created_at, started_at, completed_at, updated_at,
 			effective_keyspace_start, effective_keyspace_end, effective_keyspace_processed,
 			progress_percent, average_speed
@@ -45,6 +46,7 @@ func (r *JobTaskRepository) GetAllTasksByJobExecution(ctx context.Context, jobEx
 			&task.BenchmarkSpeed, &task.ChunkDuration,
 			&task.CrackCount, &task.DetailedStatus, &task.RetryCount,
 			&task.ErrorMessage,
+			&task.FailureReason,
 			&task.CreatedAt, &task.StartedAt, &task.CompletedAt, &task.UpdatedAt,
 			&task.EffectiveKeyspaceStart, &task.EffectiveKeyspaceEnd, &task.EffectiveKeyspaceProcessed,
 			&task.ProgressPercent, &task.AverageSpeed,

--- a/backend/internal/services/hashlist_completion_service.go
+++ b/backend/internal/services/hashlist_completion_service.go
@@ -173,31 +173,19 @@ func (s *HashlistCompletionService) stopJobTasks(ctx context.Context, jobID uuid
 
 		// Only send stop signals for running or assigned tasks
 		if task.AgentID != nil && (task.Status == models.JobTaskStatusRunning || task.Status == models.JobTaskStatusAssigned) {
-			// Check if task has completed its keyspace (race condition: task finished but status not updated yet)
-			// If keyspace is complete, mark as completed instead of cancelling
-			if task.KeyspaceEnd > 0 && task.KeyspaceProcessed >= task.KeyspaceEnd {
-				debug.Info("Task %s has completed its keyspace (%d/%d), marking as completed instead of cancelled",
-					task.ID, task.KeyspaceProcessed, task.KeyspaceEnd)
+			// GH #62: Terminalize this sibling as 'cancelled'. Previously we
+			// tried to detect "keyspace already crossed" and mark completed,
+			// or marked the task 'processing' and forced its progress to 100%
+			// — both interacted with the buggy keyspace-crossing completion
+			// path and could leave the task non-terminal while hashcat was
+			// still running. All hashes are already cracked, so this chunk's
+			// remaining keyspace is moot: send the stop signal so the agent
+			// kills hashcat, then mark the task TERMINAL as 'cancelled'.
+			//
+			// Invariant: the DB must NEVER be job=completed with a task in
+			// {running,assigned,processing,pending}. 'cancelled' (NOT 'failed')
+			// is used so HasFailedTasks does not flip the job to 'failed'.
 
-				if err := s.jobTaskRepo.UpdateStatus(ctx, task.ID, models.JobTaskStatusCompleted); err != nil {
-					debug.Error("Failed to mark task %s as completed: %v", task.ID, err)
-				}
-				continue
-			}
-
-			// Also check effective keyspace for brute-force tasks
-			if task.EffectiveKeyspaceEnd != nil && task.EffectiveKeyspaceEnd.IsPositive() &&
-				task.EffectiveKeyspaceProcessed != nil && task.EffectiveKeyspaceProcessed.Cmp(*task.EffectiveKeyspaceEnd) >= 0 {
-				debug.Info("Task %s has completed its effective keyspace (%s/%s), marking as completed instead of cancelled",
-					task.ID, task.EffectiveKeyspaceProcessed.String(), task.EffectiveKeyspaceEnd.String())
-
-				if err := s.jobTaskRepo.UpdateStatus(ctx, task.ID, models.JobTaskStatusCompleted); err != nil {
-					debug.Error("Failed to mark task %s as completed: %v", task.ID, err)
-				}
-				continue
-			}
-
-			// Task hasn't finished - send stop signal and mark as processing
 			// Create stop message payload
 			stopPayload := map[string]string{
 				"task_id": task.ID.String(),
@@ -214,7 +202,7 @@ func (s *HashlistCompletionService) stopJobTasks(ctx context.Context, jobID uuid
 				"payload": json.RawMessage(payloadJSON),
 			}
 
-			// Send stop signal to the agent
+			// Send stop signal to the agent FIRST so it kills hashcat
 			if s.wsHandler != nil {
 				if err := s.wsHandler.SendMessage(*task.AgentID, stopMsg); err != nil {
 					debug.Error("Failed to send stop signal to agent %d for task %s: %v", *task.AgentID, task.ID, err)
@@ -226,16 +214,12 @@ func (s *HashlistCompletionService) stopJobTasks(ctx context.Context, jobID uuid
 				debug.Warning("WebSocket handler not available, cannot send stop signal to agent %d", *task.AgentID)
 			}
 
-			// Part 18c: Update task keyspace to 100% before marking as processing
-			// This ensures progress displays correctly even though task was interrupted
-			if err := s.markTaskComplete100Percent(ctx, &task); err != nil {
-				debug.Error("Failed to update task %s keyspace to 100%%: %v", task.ID, err)
-			}
-
-			// Part 18b: Mark as "processing" instead of "cancelled" so remaining cracks can be recorded
-			// The task will complete normally once all pending crack batches are processed
-			if err := s.jobTaskRepo.UpdateStatus(ctx, task.ID, models.JobTaskStatusProcessing); err != nil {
-				debug.Error("Failed to update task %s status to processing: %v", task.ID, err)
+			// Mark the sibling TERMINAL as 'cancelled' and clear the agent's
+			// busy status atomically. Do NOT force progress_percent=100 — the
+			// chunk did not finish; it was stopped because the hashlist is
+			// already fully cracked.
+			if err := s.jobTaskRepo.CancelTaskAndClearAgentStatus(ctx, task.ID, *task.AgentID); err != nil {
+				debug.Error("Failed to cancel task %s and clear agent status: %v", task.ID, err)
 			}
 			continue
 		}
@@ -327,6 +311,23 @@ func (s *HashlistCompletionService) completeJob(ctx context.Context, job *models
 	if err := s.jobExecRepo.UpdateProgressPercent(ctx, job.ID, 100.0); err != nil {
 		debug.Warning("Failed to set job %s progress to 100%%: %v", job.ID, err)
 		// Not fatal - continue with completion
+	}
+
+	// GH #62 defense-in-depth: reconcile any still-non-terminal task for this
+	// job to 'cancelled' before completing. stopJobTasks should already have
+	// terminalized every sibling, but a lost WS stop message could leave a
+	// task running/assigned/processing/pending — and the invariant is that the
+	// DB is NEVER job=completed with a non-terminal task. Best-effort: log on
+	// error, don't abort completion.
+	if res, reconErr := s.db.ExecContext(ctx, `
+		UPDATE job_tasks
+		SET status = 'cancelled', completed_at = NOW()
+		WHERE job_execution_id = $1
+		  AND status IN ('assigned', 'running', 'processing', 'pending')
+	`, job.ID); reconErr != nil {
+		debug.Error("Failed to reconcile non-terminal tasks to cancelled for job %s: %v", job.ID, reconErr)
+	} else if affected, _ := res.RowsAffected(); affected > 0 {
+		debug.Warning("Reconciled %d non-terminal task(s) to 'cancelled' for job %s before completion — a WS stop signal was likely lost", affected, job.ID)
 	}
 
 	// Mark job as completed (this also sets completed_at)

--- a/backend/internal/services/job_execution_service.go
+++ b/backend/internal/services/job_execution_service.go
@@ -2045,6 +2045,25 @@ func (s *JobExecutionService) CompleteJobExecution(ctx context.Context, jobExecu
 		}
 	}
 
+	// GH #62 defense-in-depth: reconcile any still-non-terminal task for this
+	// job to 'cancelled' before completing. This covers the code-6 bypass in
+	// ProcessJobCompletion (job_scheduling_service.go), which races the async
+	// HandleHashlistFullyCracked goroutine and can reach here while a sibling
+	// task is still running/assigned/processing/pending. Invariant: the DB is
+	// NEVER job=completed with a non-terminal task. 'cancelled' (NOT 'failed')
+	// keeps HasFailedTasks from flipping the job to 'failed'. Best-effort:
+	// log on error, don't abort completion.
+	if res, reconErr := s.db.ExecContext(ctx, `
+		UPDATE job_tasks
+		SET status = 'cancelled', completed_at = NOW()
+		WHERE job_execution_id = $1
+		  AND status IN ('assigned', 'running', 'processing', 'pending')
+	`, jobExecutionID); reconErr != nil {
+		debug.Error("Failed to reconcile non-terminal tasks to cancelled for job %s: %v", jobExecutionID, reconErr)
+	} else if affected, _ := res.RowsAffected(); affected > 0 {
+		debug.Warning("Reconciled %d non-terminal task(s) to 'cancelled' for job %s before completion — a WS stop signal was likely lost", affected, jobExecutionID)
+	}
+
 	// Mark the job as completed
 	err = s.jobExecRepo.CompleteExecution(ctx, jobExecutionID)
 	if err != nil {
@@ -2438,8 +2457,11 @@ func (s *JobExecutionService) UpdateTaskProgress(ctx context.Context, taskID uui
 		chunkEff := task.EffectiveKeyspaceEnd.Sub(*task.EffectiveKeyspaceStart)
 		if chunkEff.IsPositive() {
 			localPercent := float64(effectiveKeyspaceProcessed) / float64(chunkEff.Int64()) * 100.0
-			if localPercent > 100.0 {
-				localPercent = 100.0
+			if localPercent >= 100.0 {
+				localPercent = 99.99 // reserve 100.0 for terminal completion writes (CompleteTask / code-6 path)
+			}
+			if localPercent < 0 {
+				localPercent = 0
 			}
 			progressPercent = localPercent
 		}

--- a/backend/internal/services/scheduler/cycle.go
+++ b/backend/internal/services/scheduler/cycle.go
@@ -39,6 +39,15 @@ type WSSender interface {
 	// in the DB). Implementations should return false for unknown
 	// agent IDs.
 	WasRecentlyRejected(agentID int) bool
+	// IsFileMapReady reports whether the agent has finished its startup
+	// file-map build and is safe to dispatch to (GH #61). Returns true
+	// unless the agent has EXPLICITLY reported file_map_ready=false on its
+	// periodic agent_status message. Fail-open: unknown agents (older
+	// versions that never report the field, or agents whose first status
+	// hasn't arrived) are treated as ready, mirroring the semantics of
+	// IsShuttingDown/WasRecentlyRejected. Implementations should return
+	// true for unknown agent IDs.
+	IsFileMapReady(agentID int) bool
 }
 
 // Cycle is the scheduler-v2 dispatch pipeline. Holds long-lived
@@ -839,6 +848,15 @@ func (c *Cycle) getIdleAgents(ctx context.Context) ([]AgentInfo, error) {
 		}
 		if c.wsSender.WasRecentlyRejected(agentID) {
 			debug.Debug("scheduler-v2: agent %d in rejection cooldown; skipping this cycle", agentID)
+			continue
+		}
+		// Skip agents that EXPLICITLY reported their startup file map isn't
+		// built yet. Dispatching to one would only earn a rejection that the
+		// backend records as a permanent failed task row (GH #61). Fail-open:
+		// agents that never report readiness (older versions) return true here
+		// and stay eligible.
+		if !c.wsSender.IsFileMapReady(agentID) {
+			debug.Debug("scheduler-v2: agent %d file map not ready; skipping this cycle", agentID)
 			continue
 		}
 		live = append(live, agentID)

--- a/backend/internal/services/websocket/service.go
+++ b/backend/internal/services/websocket/service.go
@@ -138,6 +138,13 @@ type AgentStatusPayload struct {
 	UpdatedAt   time.Time              `json:"updated_at"`
 	Environment map[string]string      `json:"environment"`
 	OSInfo      map[string]interface{} `json:"os_info,omitempty"`
+	// FileMapReady is the agent's startup MD5-map readiness (GH #61). It is a
+	// pointer on purpose: nil means the agent never reported it (an older agent,
+	// or a status emitted before the field existed) and MUST stay dispatch
+	// eligible; only an explicit false gates the agent out of scheduler-v2
+	// dispatch. The readiness is tracked in the handler layer and read by the
+	// scheduler via Handler.IsFileMapReady.
+	FileMapReady *bool `json:"file_map_ready,omitempty"`
 }
 
 // AgentUpdateCommandPayload instructs an agent (via its launcher) to

--- a/docs/developer/agent.md
+++ b/docs/developer/agent.md
@@ -73,6 +73,23 @@ func main() {
 }
 ```
 
+### Startup File Map and Job-Acceptance Gate (GH #61)
+
+Right after the WebSocket connection is established, the agent kicks off `conn.BuildFileMap()` in
+the background (`cmd/agent/main.go`). This walks the local wordlist, rule, and binary directories
+and builds an MD5 map of what's on disk (`PopulateHashCache`), then calls `MarkFileMapReady()`.
+Building the map up front makes the first job's per-file MD5 pre-flight a warm-cache check instead
+of a cold multi-GB re-hash on the critical path.
+
+Until the map is ready, `ProcessJobAssignment` **rejects** any task assignment with a `file map
+not ready` error. On its own a rejection is not free — the backend records the rejected assignment
+as a failed task row. To avoid that, the agent advertises its readiness through the `file_map_ready`
+field on its periodic `agent_status` message, and the scheduler-v2 dispatcher **skips any agent that
+hasn't reported ready**, holding dispatch until the map is built rather than dispatching, getting
+rejected, and stranding a failed row. The agent-side rejection remains as a backstop for any
+assignment that races through before the gate sees the agent as not-ready. Building the map is
+non-blocking, so heartbeats and status reporting continue normally while it runs.
+
 ## Hardware Detection System
 
 The agent uses hashcat's built-in device detection to identify available compute devices (GPUs and CPUs).
@@ -186,7 +203,15 @@ type JobManager struct {
 func (jm *JobManager) ProcessJobAssignment(ctx context.Context, assignmentData []byte) error {
     var assignment JobTaskAssignment
     err := json.Unmarshal(assignmentData, &assignment)
-    
+
+    // 0. Reject if the startup file map isn't built yet (GH #61).
+    //    The scheduler-v2 readiness gate normally prevents dispatch to a
+    //    not-ready agent (it waits for file_map_ready); this is the
+    //    agent-side backstop for an assignment that slips through.
+    if !jm.FileMapReady() {
+        return fmt.Errorf("file map not ready")
+    }
+
     // 1. Ensure hashlist is available
     err = jm.ensureHashlist(ctx, &assignment)
     
@@ -543,6 +568,14 @@ func (jm *JobManager) calculateProgress(hashcatStatus map[string]interface{}) fl
 }
 ```
 
+!!! note "Backend recomputes this for display"
+    `calculateProgress` returns hashcat's **absolute** ratio over the whole job. For a chunk
+    dispatched with `--skip > 0` that starts high — a chunk at the job's midpoint reports ~50% on
+    its very first update. The backend therefore **recomputes** the reported percent as a
+    *chunk-local* fraction — `effective_processed / chunk_effective_size × 100` — and **caps a
+    running chunk at 99.99%**, reserving 100% for a terminal completion write, so each chunk reads
+    0% → 100% over its own lifetime (`backend/internal/services/job_execution_service.go`, "Step 11r").
+
 ## WebSocket Communication
 
 The agent maintains a persistent WebSocket connection with the backend for real-time communication.
@@ -570,7 +603,7 @@ const (
     WSTypeHardwareInfo         WSMessageType = "hardware_info"
     WSTypeMetrics              WSMessageType = "metrics"
     WSTypeHeartbeat            WSMessageType = "heartbeat"
-    WSTypeAgentStatus          WSMessageType = "agent_status"
+    WSTypeAgentStatus          WSMessageType = "agent_status"  // payload carries file_map_ready (startup MD5-map readiness)
     WSTypeFileSyncRequest      WSMessageType = "file_sync_request"
     WSTypeFileSyncResponse     WSMessageType = "file_sync_response"
     WSTypeTaskAssignment       WSMessageType = "task_assignment"

--- a/docs/developer/backend.md
+++ b/docs/developer/backend.md
@@ -728,7 +728,7 @@ KrakenHashes uses JSON-based WebSocket messages with a `type` field for routing.
 type JobProgress struct {
     TaskID            uuid.UUID `json:"task_id"`
     KeyspaceProcessed int64     `json:"keyspace_processed"`
-    ProgressPercent   float64   `json:"progress_percent"`
+    ProgressPercent   float64   `json:"progress_percent"`     // For running tasks the backend recomputes this chunk-locally and caps it at 99.99% (100% reserved for terminal completion)
     HashRate          int64     `json:"hash_rate"`
     CrackedCount      int       `json:"cracked_count"`        // Expected cracks when Status="completed"
     Status            string    `json:"status"`               // "running" or "completed"

--- a/docs/reference/architecture/chunking.md
+++ b/docs/reference/architecture/chunking.md
@@ -88,6 +88,9 @@ The system tracks progress through the virtual keyspace while hashcat processes 
 - Updates in real-time via WebSocket
 - Accurate percentage completion
 
+### Running Chunk Progress
+While a chunk is running, its `progress_percent` is recomputed chunk-locally (0% at start, capped at 99.99%), with exactly 100% reserved for terminal completion so an in-flight chunk never displays as finished. The per-task monotonic guard applies only to `keyspace_processed` (which never moves backward), not to `progress_percent`, which is a derived display value (see `backend/internal/repository/job_task_repository.go` ~783-806).
+
 ### With Rule Multiplication
 - Display format: "X / Y (×Z)" where Z is the multiplication factor
 - Accounts for all rules across all chunks

--- a/docs/reference/architecture/file-hash-cache.md
+++ b/docs/reference/architecture/file-hash-cache.md
@@ -4,6 +4,9 @@
 
 The File Hash Cache is an in-memory caching system that optimizes the directory monitor service by eliminating redundant MD5 hash calculations for unchanged files. This dramatically reduces disk I/O and prevents SSD wear in deployments with large wordlists and rule files.
 
+!!! note "Scope: backend cache only"
+    This document covers the **backend** file hash cache used by the directory monitor. The **agent** maintains a separate startup MD5 file-map, built at boot via `BuildFileMap` → `PopulateHashCache` (GH #61), which gates job acceptance and dispatch until the agent's local wordlist/rule/binary hashes are known. See [Agent Development](../../developer/agent.md) and the [Scheduler v2 Overview](scheduler-v2-overview.md) for that agent-side flow.
+
 ## Problem Statement
 
 The directory monitor service runs every 30 seconds to detect changes in wordlist and rule files. Before the cache implementation:

--- a/docs/reference/architecture/job-completion-system.md
+++ b/docs/reference/architecture/job-completion-system.md
@@ -35,6 +35,7 @@ When status code 6 is received:
 1. **Identify All Affected Jobs**: Query for ALL jobs (any status) targeting the same hashlist
 2. **Running Jobs**:
    - Send WebSocket stop signals to active agents
+   - Terminalize each active sibling task as `'cancelled'` (not left `processing`, not forced to 100%) before the job is completed
    - Mark jobs as "completed" at 100% progress
    - Send completion email notifications
 3. **Pending Jobs**:
@@ -97,9 +98,12 @@ In `backend/internal/routes/websocket_with_jobs.go`:
 2. **Process Running Jobs**:
    - Find active tasks for each running job
    - Send stop signals via WebSocket
+   - Terminalize each active sibling task as `'cancelled'` — `'cancelled'` (not `'failed'`) keeps the job from flipping to failed, and the task's progress is **not** forced to 100% because the chunk was stopped, not finished
    - Update job status to 'completed'
    - Set progress to 100%
    - Trigger email notifications
+
+   **Invariant:** The job is never marked completed while a sibling task is still `running`, `processing`, or `pending` — each active sibling is terminalized to `'cancelled'` first (via `CancelTaskAndClearAgentStatus`).
 
 3. **Process Pending Jobs**:
    - Delete jobs that haven't started

--- a/docs/reference/architecture/scheduler-v2-overview.md
+++ b/docs/reference/architecture/scheduler-v2-overview.md
@@ -39,7 +39,9 @@ performs these steps and commits its own work:
 3. **Select schedulable units** — find the jobs (and increment-mode layers) that have uncovered
    keyspace and are otherwise ready to run.
 4. **Allocate agents by priority** — assign idle, compatible agents to those units (see
-   [Agent allocation](#agent-allocation-and-overflow-modes)).
+   [Agent allocation](#agent-allocation-and-overflow-modes)). An agent is only considered
+   dispatchable once it reports its startup file map is ready (`file_map_ready`); an agent still
+   building that map is skipped for the cycle so it isn't handed a chunk it would only reject.
 5. **Dispatch one chunk per agent** — create the next chunk for each allocated agent from its job's
    first uncovered coverage gap.
 6. **Commit** — persist the cycle's intervals and tasks.
@@ -100,7 +102,9 @@ modes are available:
 The "Priority" family concentrates agents on the highest tier that can use them; the "Max Agents"
 family guarantees every job its baseline cap first and then accelerates higher-priority work with the
 extras. A core invariant holds in all modes: **a compatible agent is never left idle while a
-compatible job still has dispatchable work.** Higher-priority running tasks can also interrupt
+compatible job still has dispatchable work** — except that an agent still building its startup file
+map is intentionally skipped until it reports `file_map_ready` (fail-open: an agent that never
+reports readiness stays eligible). Higher-priority running tasks can also interrupt
 lower-priority ones when interruption is enabled — see [Job Priority](../../admin-guide/advanced/job-priority.md).
 
 ## Chunking and dispatch

--- a/docs/user-guide/jobs-workflows.md
+++ b/docs/user-guide/jobs-workflows.md
@@ -377,6 +377,10 @@ The completed tasks history helps with:
 !!! tip "Performance Insights"
     Use the completed tasks table to identify your most efficient agents and optimize task distribution in future jobs.
 
+#### Failed Tasks
+
+The Job Details page also includes a Failed Tasks table listing any tasks that did not complete successfully. Alongside the agent, task ID, status, and retry count, each row now shows the failure reason inline, so you can usually see why a task failed without opening the logs. If no reason was recorded, the table displays "No error message".
+
 ### Interactive Controls
 
 While monitoring your job, you can:

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -133,6 +133,7 @@ This guide helps you resolve common issues when using KrakenHashes. If your issu
 
 **Error**: `Hashcat execution failed`
 - **Solution**:
+  - Check the failed-tasks table on the Job Details page, which now shows the failure reason inline (you often won't need the logs just to see why it failed)
   - Check job logs for specific hashcat errors
   - Verify hash format matches selected type
   - Ensure wordlists/rules are accessible

--- a/frontend/src/components/JobProgressBar.tsx
+++ b/frontend/src/components/JobProgressBar.tsx
@@ -161,7 +161,11 @@ const JobProgressBar: React.FC<JobProgressBarProps> = ({
                   Keyspace: {formatKeyspace(segment.task.effective_keyspace_start ?? segment.task.keyspace_start)} - {formatKeyspace(segment.task.effective_keyspace_end ?? segment.task.keyspace_end)}
                 </Typography>
                 <Typography variant="body2">
-                  Progress: {segment.task.progress_percent?.toFixed(2) || 0}%
+                  Progress: {(() => {
+                    const p = segment.task.progress_percent ?? 0;
+                    const shown = segment.task.status === 'running' ? Math.min(p, 99.99) : p;
+                    return shown.toFixed(2);
+                  })()}%
                 </Typography>
                 {segment.task.benchmark_speed && (
                   <Typography variant="body2">
@@ -211,7 +215,7 @@ const JobProgressBar: React.FC<JobProgressBarProps> = ({
                   sx={{
                     position: 'absolute',
                     left: 0,
-                    width: `${segment.task.progress_percent}%`,
+                    width: `${Math.min(segment.task.progress_percent ?? 0, 99.99)}%`,
                     height: '100%',
                     backgroundColor: 'rgba(255, 255, 255, 0.3)',
                     transition: 'width 0.3s ease'

--- a/frontend/src/pages/Jobs/JobDetails.tsx
+++ b/frontend/src/pages/Jobs/JobDetails.tsx
@@ -1265,7 +1265,11 @@ const JobDetails: React.FC = () => {
                     <TableCell>
                       {formatKeyspace(task.effective_keyspace_start || task.keyspace_start)} - {formatKeyspace(task.effective_keyspace_end || task.keyspace_end)}
                     </TableCell>
-                    <TableCell>{task.progress_percent?.toFixed(2) || 0}%</TableCell>
+                    <TableCell>{(() => {
+                      const p = task.progress_percent ?? 0;
+                      const shown = task.status === 'running' ? Math.min(p, 99.99) : p;
+                      return shown.toFixed(2);
+                    })()}%</TableCell>
                     <TableCell>{formatSpeed(task.benchmark_speed)}</TableCell>
                     <TableCell>
                       {task.crack_count > 0 ? (
@@ -1332,7 +1336,7 @@ const JobDetails: React.FC = () => {
                     <TableCell>{task.retry_count || 0}</TableCell>
                     <TableCell>
                       <Typography variant="body2" sx={{ maxWidth: 300 }}>
-                        {task.error_message || t('common.noErrorMessage')}
+                        {task.error_message || task.failure_reason || t('common.noErrorMessage')}
                       </Typography>
                     </TableCell>
                     <TableCell>{formatDate(task.updated_at)}</TableCell>

--- a/frontend/src/types/jobs.ts
+++ b/frontend/src/types/jobs.ts
@@ -106,6 +106,7 @@ export interface JobTask {
   completed_at?: string;
   last_checkpoint?: string;
   error_message?: string;
+  failure_reason?: string;
   crack_count: number;
   expected_crack_count?: number;
   received_crack_count?: number;


### PR DESCRIPTION
## Summary

Fixes the GH #62 chunk-progress / premature-completion bug, and two pre-existing scheduler-v2 issues found while verifying that fix on real hardware.

## GH #62 — chunk progress display + premature job completion

Root cause: for slow salted/rule modes, hashcat's reported/estimated progress reaches a chunk's *estimated* boundary before the chunk actually finishes, and the system treated "reported keyspace crossed the estimate" as "chunk done."

- **Display cap** — running-task `progress_percent` is capped at **99.99%** (100% reserved for terminal completion writes) and the monotonic guard no longer freezes it at 100.
- **No premature completion** — removed the keyspace-crossing auto-complete; a task/job completes only from the agent's **explicit hashcat-exit** signal.
- **Agent** — on hashcat status code 6 (all-cracked) the agent keeps `AllHashesCracked` but reports `status="running"`, not `"completed"`, until the process exits.
- **All-hashes-cracked flow** — sibling tasks are terminalized to `cancelled` (new `CancelTaskAndClearAgentStatus`) before the job completes; defense-in-depth reconcile guards added in `completeJob` / `CompleteJobExecution` so the DB is never `job=completed` with a live task.
- **Frontend** — running chunks clamp below 100% in the progress bar and detail tables.

## Scheduler-v2 fixes (discovered during #62 verification — no prior issue)

- **Orphaned `pending`-at-100% tasks hung jobs.** A stop-ack arriving after the heartbeat sweeper already recovered a chunk to a terminal state was clobbering it back to `pending` (via `ClearTaskAgentAndSetPending`, which had no status guard). That orphan then blocked `GetIncompleteTasksCount`/`ProcessJobCompletion` **and** hid the job from the stuck-job reconciler → the job never completed. **Fix:** guard the update with `status NOT IN ('completed','cancelled','failed')`, making a post-recovery stop-ack a safe no-op.
- **Dispatch-to-not-ready-agent → permanent `failed` rows.** The scheduler had no visibility into an agent's startup file-map build, so it dispatched into an agent that would only reject ("file map not ready"), and each rejection became a permanent `failed` task row (~6 per agent restart). **Fix:** a readiness gate — the agent reports `file_map_ready` on its periodic `agent_status` message; the backend tracks it in-memory (mirroring `IsShuttingDown`) and `getIdleAgents` skips agents that explicitly report not-ready. **Fail-open** for older agents (absence of the field ⇒ eligible) and **self-healing** across a backend restart.
- **Surface `failure_reason`.** It was a write-only DB column (never read into the model or sent by the API), so genuine failures showed "No error message." Now wired through model → repo scans → API → TS type → UI fallback.

## Testing

Verified end-to-end with a real hashcat agent (mode 5600 + rules); logs confirm:
- Readiness gate fired during agent startup (agent reported `file_map_ready=false` → `true`); gate skipped the not-ready agent; **zero** file-map-not-ready `failed` rows created.
- **Zero** `pending`+`completed_at` orphan rows across all jobs.
- Running chunks held at 99.99% while running; `failure_reason` now surfaced in the failed-tasks table.

No DB migration required. The agent change (readiness signal) requires rebuilding/redeploying agents; the gate is backward-compatible with un-upgraded agents.

Fixes #62
Relates to #61 (agent file-map sync / dispatch readiness)

https://claude.ai/code/session_01KSkpGuUtkewfpu3dmvyV1t


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixes the GUI showing prematurely finished chunk/job progress by reserving 100% exclusively for terminal completion, routing “all hashes cracked” completion through explicit completion handling, and hardening sibling-task cancellation/reconciliation so completed jobs don’t retain live tasks. Also addresses scheduler-v2 reliability issues by adding an agent “startup file map ready” gate (`file_map_ready`) that prevents dispatching to recovered agents until their MD5 map is initialized, and surfaces `failure_reason` throughout the job task API/UI without requiring any database migration.

- **Backend**
  - Fixes premature completion/progress:
    - `runHashcatProcess` now keeps progress as `"running"` during streaming updates and defers emitting real `"completed"` to process-exit handling.
    - `HandleJobProgress` no longer auto-completes based on `keyspace_processed == keyspace_end`; completion now flows via explicit `"completed"` status (hashcat exit) and the all-hashes-cracked path.
    - Chunk/local progress recalculation clamps running progress to **99.99%** (reserving 100% for terminal completion).
  - Hardens task/job terminalization:
    - Sibling tasks terminated as `cancelled` (instead of force-progress/processing hacks) during stop flows.
    - Adds defense-in-depth reconciliation to ensure a job cannot be marked completed while any sibling task remains non-terminal.
    - Protects against late stop acknowledgements (no-ops if task already reached a terminal state).
  - Scheduler-v2 dispatch gating:
    - Adds `file_map_ready` to the agent status model/schema and uses it to exclude agents from dispatch when they explicitly report `file_map_ready=false` (fail-open for older agents/unknown readiness).
    - Adds a readiness cache and readiness-specific handler to update eligibility promptly when the MD5 map becomes ready.
    - Adds an `IsFileMapReady(agentID)` readiness check to the scheduler dispatch path.
  - API/contract changes:
    - Adds optional `failure_reason` to job task responses (propagated via models, repositories, and websocket/job detail payloads).
- **Agent**
  - Extends `agent_status` to include optional `file_map_ready` once the startup MD5 file map is initialized.
  - Backward-compatible: agents omitting the field are treated as ready.
- **Frontend**
  - Caps displayed **running** progress at **99.99%** for job/task progress bars and tooltips.
  - For failed tasks, displays `failure_reason` as the error text when `error_message` is absent.
- **Docs**
  - Updates developer docs and architecture references to describe:
    - “Running Chunk Progress” (99.99% cap; 100% reserved for terminal completion).
    - Scheduler-v2 file map readiness gating (`file_map_ready`).
    - Job completion invariants around sibling terminalization.
- **Migrations / breaking changes**
  - **No database migration required.**
  - **Redeploy agents** to start reporting `file_map_ready`; older agents remain compatible (fail-open).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->