### PR TITLE
feat: loopback re-run feature (#64) + keyspace/recovery fixes

### DIFF
--- a/agent/internal/jobs/hashcat_executor.go
+++ b/agent/internal/jobs/hashcat_executor.go
@@ -44,7 +44,23 @@ const (
 	taskErrOOM      = "AGENT_OOM"       // out of (GPU) memory
 	taskErrDiskFull = "AGENT_DISK_FULL" // no space left on device
 	taskErrWatchdog = "GPU_WATCHDOG"    // GPU watchdog / thermal alarm
+	taskErrAutotune = "AGENT_AUTOTUNE"  // kernel autotune failed → device skipped, nothing ran (retryable with --force)
+	taskErrNoWork   = "AGENT_NO_WORK"   // hashcat exited 0 but never processed any candidates
 )
+
+// isAutotuneSkip reports whether a hashcat output line indicates a kernel
+// autotune failure that skips the device. On some GPUs a tiny job trips
+// "Kernel minimum runtime larger than default TDR" → "Aborting session due to
+// kernel autotune failures, for all active devices." → "Device #N: skipped, due
+// to kernel autotune failure (-4)", after which hashcat exits 0 having tested
+// nothing. We detect this to avoid mis-reporting the task completed and to retry
+// with --force (which bypasses autotune). Checked on both stdout and stderr
+// because hashcat may route these lines to either.
+func isAutotuneSkip(line string) bool {
+	l := strings.ToLower(line)
+	return strings.Contains(l, "kernel autotune failure") ||
+		strings.Contains(l, "aborting session due to kernel autotune failures")
+}
 
 // classifyHashcatStderr maps a single hashcat stderr/stdout line to a task error
 // code, or "" if the line carries no recognized fault. Checked most-specific
@@ -72,8 +88,27 @@ func classifyHashcatStderr(line string) string {
 		strings.Contains(l, "cuinit") ||
 		strings.Contains(l, "no cuda-capable device"):
 		return taskErrDriver
-	case strings.Contains(l, "watchdog"):
+	case strings.Contains(l, "watchdog") ||
+		strings.Contains(l, "temperature limit"):
+		// GPU watchdog alarm or a thermal-limit abort ("Temperature limit on GPU
+		// #N reached, aborting"). Both stop the device mid-run; hashcat may then
+		// exit 1 ("exhausted") despite not finishing — see DeviceAbort handling.
 		return taskErrWatchdog
+	case strings.Contains(l, "memory access fault") ||
+		strings.Contains(l, "page not present or supervisor privilege"):
+		// A hard GPU driver crash mid-run — e.g. AMD ROCm/amdgpu "Memory access
+		// fault by GPU node-N (...) on address (nil). Reason: Page not present or
+		// supervisor privilege." This is a device crash, not thermal, but it's
+		// still a device abort: the GPU stops and hashcat may exit 1 ("exhausted")
+		// with progress[0] < progress[1]. Reuse taskErrWatchdog so it (a) sets
+		// DeviceAbort → the exit handler fails-not-completes and the unsearched
+		// remainder re-dispatches from the recovery point instead of counting as
+		// done, and (b) classifies transient so the agent is re-dispatched, not
+		// quarantined. NB "memory access fault" is distinct from OOM ("out of
+		// memory") above, so it lands here, not there.
+		return taskErrWatchdog
+	case isAutotuneSkip(line):
+		return taskErrAutotune
 	}
 	return ""
 }
@@ -85,6 +120,19 @@ func (p *HashcatProcess) noteStderr(line string) {
 	code := classifyHashcatStderr(line)
 	if code == "" {
 		return
+	}
+	if code == taskErrAutotune {
+		// Separate, dedicated signal: the exit-code handler consults this to
+		// avoid fake-completing a run where the device was skipped, and the
+		// executor uses it to add --force to subsequent runs.
+		p.AutotuneSkipped.Store(true)
+	}
+	if code == taskErrWatchdog {
+		// A thermal/watchdog abort stops the device mid-run; hashcat can still
+		// exit 1 ("exhausted") with progress[0] < progress[1]. The exit-code
+		// handler consults this to fail-not-complete so the unsearched remainder
+		// re-dispatches from the recovery point instead of counting as complete.
+		p.DeviceAbort.Store(true)
 	}
 	p.mutex.Lock()
 	if p.detectedErrorCode == "" {
@@ -109,6 +157,22 @@ func (p *HashcatProcess) taskFailureMessage(exitCode int, generic string) string
 		return fmt.Sprintf("%s: %s (hashcat exit %d)", code, line, exitCode)
 	}
 	return fmt.Sprintf("%s (hashcat exit %d)", code, exitCode)
+}
+
+// keyspaceExhausted reports whether the last captured hashcat status confirms the
+// task processed its ENTIRE assigned keyspace — progress[0] reached progress[1].
+// A genuine "exhausted" exit has them equal; a device that aborted mid-run
+// (thermal/watchdog) leaves progress[0] < progress[1]. Returns false when no
+// status carrying the total was ever captured (nothing is confirmed). Read
+// without a lock: the exit-code handler runs only after the output-reader
+// goroutines have joined, so LastProgress is stable by then (same as the other
+// LastProgress reads in that handler).
+func (p *HashcatProcess) keyspaceExhausted() bool {
+	lp := p.LastProgress
+	if lp == nil || lp.TotalEffectiveKeyspace == nil {
+		return false
+	}
+	return lp.EffectiveProgress >= *lp.TotalEffectiveKeyspace
 }
 
 // AttackMode represents hashcat attack modes
@@ -299,6 +363,14 @@ type HashcatExecutor struct {
 	// Agent's default extra parameters for hashcat
 	agentExtraParams string
 
+	// forceKernel is set true (sticky, agent-session-wide) the first time any
+	// task is skipped by a kernel autotune failure. Once set, every subsequent
+	// hashcat run (tasks and speed tests, which share the command builder) is
+	// launched with --force to bypass autotune, so tiny jobs stop re-failing.
+	// --force also suppresses hashcat's self-test, so we only enable it AFTER an
+	// observed autotune failure — never speculatively.
+	forceKernel atomic.Bool
+
 	// Crack batching - reduces message flood when many hashes crack simultaneously
 	crackBatchMutex    sync.Mutex
 	crackBatchBuffers  map[string][]CrackedHash // Buffer per task ID
@@ -349,7 +421,10 @@ type HashcatProcess struct {
 
 	// Error tracking
 	AlreadyRunningError     bool
-	HashcatRejectedHashlist atomic.Bool // set when stderr/stdout indicates "No hashes loaded" / "Hash parsing error" / etc. → fast-fail the job
+	HashcatRejectedHashlist atomic.Bool  // set when stderr/stdout indicates "No hashes loaded" / "Hash parsing error" / etc. → fast-fail the job
+	AutotuneSkipped         atomic.Bool  // set when hashcat skipped the device on kernel autotune failure (session aborted, nothing ran) → fail-not-complete + retry with --force
+	DeviceAbort             atomic.Bool  // set when a device aborted mid-run (thermal/watchdog). hashcat may then exit 1 ("exhausted") with progress[0] < progress[1]; treat as a failure (not completion) so the unsearched remainder re-dispatches from the recovery point
+	cracksReported          atomic.Int64 // cumulative cracks captured for this task; a nonzero count proves the run did real work even if no final status JSON was captured
 	// detectedErrorCode/Line capture the first recognized agent-local fault
 	// (OOM, no-device, driver, disk, watchdog) seen in hashcat output, so the
 	// exit-code handler can tag the failure with a typed code for the backend.
@@ -714,6 +789,26 @@ func (e *HashcatExecutor) buildHashcatCommandWithOptions(assignment *JobTaskAssi
 	if mergedArgs != "" {
 		debug.Info("Adding merged extra parameters: %s (job: %s, agent: %s)", mergedArgs, assignment.JobAdditionalArgs, agentArgs)
 		args = append(args, strings.Fields(mergedArgs)...)
+	}
+
+	// Surgical autotune remediation: once any task on this agent has been
+	// skipped by a kernel autotune failure, carry --force on every subsequent
+	// hashcat run so tiny jobs stop autotune-aborting. Only added after such a
+	// failure is observed (forceKernel is set in the exit handler), never
+	// speculatively, because --force also disables hashcat's correctness
+	// self-test. Skip if the user already supplied --force to avoid a duplicate.
+	if e.forceKernel.Load() {
+		hasForce := false
+		for _, a := range args {
+			if a == "--force" {
+				hasForce = true
+				break
+			}
+		}
+		if !hasForce {
+			args = append(args, "--force")
+			debug.Info("Adding --force (agent previously detected a kernel autotune skip)")
+		}
 	}
 
 	// Add increment flags for mask-based attacks
@@ -1128,6 +1223,13 @@ func (e *HashcatExecutor) runHashcatProcess(ctx context.Context, process *Hashca
 			line := scanner.Text()
 			lineCount++
 			debug.Debug("[Hashcat stdout raw] %s", line)
+
+			// Autotune-skip can surface on stdout (the stderr reader also watches
+			// for it). Setting this flag lets the exit handler avoid mis-reporting
+			// a skipped run as completed and trips the --force retry.
+			if isAutotuneSkip(line) {
+				process.AutotuneSkipped.Store(true)
+			}
 
 			// Store original line for outputCallback
 			originalLine := line
@@ -1589,6 +1691,18 @@ func (e *HashcatExecutor) runHashcatProcess(ctx context.Context, process *Hashca
 			e.flushCrackBatch(process)
 		}
 
+		// If any device was skipped by a kernel autotune failure this run, switch
+		// the agent to --force for every subsequent run (and this task's retry).
+		// Centralized here so it fires no matter which exit path we take —
+		// autotune can surface as exit 0 (handled by reportNoWorkIfIdle) or as an
+		// abort exit code (2-5), and both must set the flag for the monitor's
+		// --force retry to actually help.
+		if process.AutotuneSkipped.Load() {
+			if e.forceKernel.CompareAndSwap(false, true) {
+				debug.Warning("Kernel autotune skip detected for task %s — enabling --force for all subsequent hashcat runs on this agent", process.TaskID)
+			}
+		}
+
 		if err != nil {
 			// Step 11t: detect signal-killed hashcat (SIGINT from Ctrl+C
 			// propagating through the process group, SIGTERM/SIGKILL from
@@ -1636,7 +1750,13 @@ func (e *HashcatExecutor) runHashcatProcess(ctx context.Context, process *Hashca
 
 				switch exitCode {
 				case 0:
-					// OK/cracked - normal completion
+					// OK/cracked - normal completion. But a clean exit with no
+					// status ever captured means no device processed candidates
+					// (e.g. a kernel autotune abort that still exits 0). Fail
+					// instead of fake-completing so the work isn't lost.
+					if e.reportNoWorkIfIdle(process, exitCode) {
+						break
+					}
 					debug.Info("Hashcat completed with OK/cracked status for task %s", process.TaskID)
 					// Use the last progress percentage if available, otherwise 100%
 					progressPercent := 100.0
@@ -1663,6 +1783,19 @@ func (e *HashcatExecutor) runHashcatProcess(ctx context.Context, process *Hashca
 					e.sendProgressUpdate(process, finalProgress, "completed")
 
 				case 1:
+					// Exit 1 = "exhausted". But a device that aborted mid-run
+					// (thermal/watchdog) also exits 1 while its restore_point /
+					// progress[0] never reached progress[1]. Do NOT fake-complete
+					// that — it would count unsearched keyspace as done and lose
+					// work (and cracks). Fail it (transient) instead so the backend
+					// closes out coverage up to the last recovery point and
+					// re-dispatches the remainder from there. A genuine exhaustion
+					// (progress[0] == progress[1]) still completes below.
+					if process.DeviceAbort.Load() && !process.keyspaceExhausted() {
+						debug.Warning("Task %s: hashcat exit 1 (exhausted) after a device abort but the keyspace was NOT confirmed complete — failing so the unsearched remainder re-dispatches from the recovery point", process.TaskID)
+						e.sendErrorProgress(process, process.taskFailureMessage(exitCode, taskErrWatchdog+": device aborted before exhausting keyspace (thermal/watchdog)"))
+						break
+					}
 					// Exhausted - normal completion, keyspace fully processed
 					debug.Info("Hashcat exhausted keyspace for task %s", process.TaskID)
 					// Exhausted means 100% complete
@@ -1738,8 +1871,11 @@ func (e *HashcatExecutor) runHashcatProcess(ctx context.Context, process *Hashca
 			} else {
 				e.sendErrorProgress(process, fmt.Sprintf("Hashcat process failed: %v", err))
 			}
-		} else {
-			// Process completed successfully with exit code 0
+		} else if !e.reportNoWorkIfIdle(process, 0) {
+			// Process completed successfully with exit code 0.
+			// reportNoWorkIfIdle returned false, so a device actually ran and
+			// reported progress — report the genuine completion. (A clean exit
+			// with no status ever captured is failed there, not fake-completed.)
 			debug.Info("Hashcat completed successfully with exit code 0 (OK/cracked) for task %s", process.TaskID)
 			// Use the last progress values if available
 			progressPercent := 100.0
@@ -1793,6 +1929,41 @@ func (e *HashcatExecutor) sendErrorProgress(process *HashcatProcess, errorMsg st
 	e.sendProgressUpdate(process, progress, "failed")
 }
 
+// reportNoWorkIfIdle guards the "hashcat exited cleanly but no device processed
+// any candidates" case. hashcat can exit 0 (OK/cracked) yet never emit a single
+// status line when the session was aborted before running — most commonly a
+// kernel autotune failure that skips the device. Reporting such a run as
+// completed would silently under-crack the job (this truncated a loopback chain
+// one hash short during testing). When LastProgress is nil we therefore fail the
+// task instead: if an autotune skip was detected we flag the executor to add
+// --force to future runs and tag AGENT_AUTOTUNE so the monitor retries with
+// --force; otherwise we tag AGENT_NO_WORK so the backend re-dispatches.
+//
+// Returns true if it handled (failed) the task; false if the run actually
+// produced progress and the caller should report it completed. On a multi-GPU
+// agent where one device autotune-skipped but another ran to completion,
+// LastProgress is non-nil (real work happened) so the task completes normally,
+// but forceKernel is still set so the skipped device participates next time.
+func (e *HashcatExecutor) reportNoWorkIfIdle(process *HashcatProcess, exitCode int) bool {
+	if process.LastProgress != nil || process.cracksReported.Load() > 0 {
+		// A device ran and reported at least one status, or the run captured
+		// cracks — either way it did real work, so let the caller complete it.
+		return false
+	}
+	// forceKernel was already set upstream (centralized autotune check) if this
+	// run tripped autotune; here we only choose the failure message.
+	if process.AutotuneSkipped.Load() {
+		msg := process.taskFailureMessage(exitCode, taskErrAutotune+": kernel autotune failure skipped the device before any candidates were tested")
+		debug.Error("[Task %s] %s — failing task; subsequent runs on this agent will use --force", process.TaskID, msg)
+		e.sendErrorProgress(process, msg)
+		return true
+	}
+	msg := fmt.Sprintf("%s: hashcat exited %d without processing any candidates (no status ever reported)", taskErrNoWork, exitCode)
+	debug.Error("[Task %s] %s — failing task instead of reporting a no-op completion", process.TaskID, msg)
+	e.sendErrorProgress(process, msg)
+	return true
+}
+
 // addCrackToBatch adds a cracked hash to the batch buffer for the given task.
 // Batches are flushed after 500ms timer OR when buffer reaches 10k cracks (WebSocket limit).
 // This balances efficiency with WebSocket message size constraints.
@@ -1809,6 +1980,11 @@ func (e *HashcatExecutor) addCrackToBatch(process *HashcatProcess, cracked *Crac
 
 	// Add crack to buffer
 	e.crackBatchBuffers[taskID] = append(e.crackBatchBuffers[taskID], *cracked)
+
+	// Count it: a nonzero total proves this task did real work, so the exit
+	// handler won't mistake a fast crack-then-exit (that raced past its final
+	// status line) for a no-op run.
+	process.cracksReported.Add(1)
 
 	// Flush immediately if buffer reaches 10k cracks (WebSocket message size limit)
 	// Otherwise let the timer handle batching naturally
@@ -2130,6 +2306,12 @@ func (e *HashcatExecutor) RunSpeedTest(ctx context.Context, assignment *JobTaskA
 				strings.Contains(line, "Separator unmatched") {
 				hashcatRejectedHashlist.Store(true)
 			}
+			// A benchmark can also trip a kernel autotune skip on tiny/flaky
+			// devices. Set the sticky force flag so a retry of this benchmark —
+			// and every subsequent run — is launched with --force to bypass it.
+			if isAutotuneSkip(line) {
+				e.forceKernel.Store(true)
+			}
 			var jsonPart string
 			if strings.Contains(line, ":") && strings.Contains(line, "{") && strings.Contains(line, "\"status\"") {
 				jsonStart := strings.Index(line, "{")
@@ -2162,6 +2344,11 @@ func (e *HashcatExecutor) RunSpeedTest(ctx context.Context, assignment *JobTaskA
 			// timeout path returns the typed sentinel.
 			if strings.Contains(line, "No hashes loaded") {
 				hashcatRejectedHashlist.Store(true)
+			}
+			// See the stdout reader: a kernel autotune skip during the benchmark
+			// sets the sticky force flag so the retry uses --force.
+			if isAutotuneSkip(line) {
+				e.forceKernel.Store(true)
 			}
 		}
 	}()

--- a/agent/internal/jobs/jobs.go
+++ b/agent/internal/jobs/jobs.go
@@ -1259,6 +1259,16 @@ func (jm *JobManager) monitorJobProgress(ctx context.Context, jobExecution *JobE
 					continue
 				}
 
+				// A kernel-autotune skip surfaces here as a normal "failed" progress
+				// tagged AGENT_AUTOTUNE (see hashcat_executor.reportNoWorkIfIdle). We
+				// do NOT retry it in-agent: the executor already set its sticky
+				// forceKernel flag on detection, so we let the failure flow to the
+				// backend (via statusCallback below), which classifies AGENT_AUTOTUNE
+				// as transient and re-dispatches a fresh task — that re-run builds
+				// with --force and runs. (An in-agent retry reusing the same TaskID
+				// races ExecuteTask's "already running" guard and would be silently
+				// dropped, since the legacy progressCallback is nil in production.)
+
 				// Send to backend via dual callbacks (new approach)
 				jm.mutex.RLock()
 				hasStatusCallback := jm.statusCallback != nil

--- a/agent/internal/sync/sync.go
+++ b/agent/internal/sync/sync.go
@@ -600,6 +600,19 @@ func (fs *FileSync) DownloadFileWithInfoRetry(ctx context.Context, fileInfo *Fil
 	var targetDir string
 	var finalPath string
 
+	// Acquire a download slot BEFORE any retryOrFailInfo can run, so that helper
+	// can always safely release/re-acquire the slot around its backoff (a
+	// repeatedly-failing or slow download must not pin a slot and starve
+	// task-critical downloads like the hashlist). Held for the whole attempt and
+	// released on every return by the defer below.
+	select {
+	case fs.sem <- struct{}{}:
+		defer func() { <-fs.sem }()
+	case <-ctx.Done():
+		debug.Error("Context cancelled while waiting for download slot: %v", ctx.Err())
+		return ctx.Err()
+	}
+
 	switch fileInfo.FileType {
 	case "wordlist":
 		// The backend includes the category in the Name field (e.g., "general/file.txt")
@@ -690,15 +703,6 @@ func (fs *FileSync) DownloadFileWithInfoRetry(ctx context.Context, fileInfo *Fil
 		return fmt.Errorf("unsupported file type: %s", fileInfo.FileType)
 	}
 
-	// Acquire semaphore slot
-	select {
-	case fs.sem <- struct{}{}:
-		defer func() { <-fs.sem }()
-	case <-ctx.Done():
-		debug.Error("Context cancelled while waiting for download slot: %v", ctx.Err())
-		return ctx.Err()
-	}
-
 	// Create parent directory for the final file path
 	parentDir := filepath.Dir(finalPath)
 	if err := os.MkdirAll(parentDir, 0750); err != nil {
@@ -776,6 +780,20 @@ func (fs *FileSync) DownloadFileWithInfoRetry(ctx context.Context, fileInfo *Fil
 			url = fmt.Sprintf("%s/api/files/%s/%s", fs.urlConfig.BaseURL, fileInfo.FileType, fileInfo.Name)
 		}
 	}
+	// The global potfile is continuously appended, so its recorded md5 only covers
+	// the prefix [0, Size). Ask the server for exactly that prefix (?bytes=N) so the
+	// downloaded bytes verify against fileInfo.MD5Hash (see the backend's bounded
+	// serve) instead of the larger current file — keeping verification meaningful
+	// without ever accepting a stale copy. Immutable files set Size == on-disk size,
+	// so bounding them is a harmless no-op.
+	if fileInfo.FileType == "wordlist" && strings.HasSuffix(fileInfo.Name, "potfile.txt") && fileInfo.Size > 0 {
+		sep := "?"
+		if strings.Contains(url, "?") {
+			sep = "&"
+		}
+		url = fmt.Sprintf("%s%sbytes=%d", url, sep, fileInfo.Size)
+	}
+
 	debug.Info("Downloading file from %s", url)
 
 	// Create request
@@ -910,11 +928,24 @@ func (fs *FileSync) retryOrFailInfo(ctx context.Context, fileInfo *FileInfo, ret
 	debug.Warning("Retrying download of %s in %v (attempt %d/%d): %v",
 		fileInfo.Name, delay, retryCount+2, fs.maxRetries+1, err)
 
+	// Release the download slot for the duration of the backoff + next attempt.
+	// This function is always reached while the caller (DownloadFileWithInfoRetry)
+	// holds one fs.sem slot; without this, a repeatedly-failing or slow download
+	// would pin that slot across every backoff sleep and nested retry, starving
+	// task-critical downloads (e.g. the hashlist) that share the same pool. The
+	// recursive DownloadFileWithInfoRetry re-acquires its own slot for the retry;
+	// we then re-acquire one here so the caller's deferred `<-fs.sem` stays balanced.
+	<-fs.sem
+	reacquire := func() { fs.sem <- struct{}{} }
+
 	select {
 	case <-time.After(delay):
-		return fs.DownloadFileWithInfoRetry(ctx, fileInfo, retryCount+1)
+		err := fs.DownloadFileWithInfoRetry(ctx, fileInfo, retryCount+1)
+		reacquire()
+		return err
 	case <-ctx.Done():
 		debug.Error("Context cancelled while waiting for retry: %v", ctx.Err())
+		reacquire()
 		return ctx.Err()
 	}
 }
@@ -964,9 +995,13 @@ func (fs *FileSync) SyncDirectory(ctx context.Context, fileType string) error {
 		go func(file FileListEntry) {
 			defer wg.Done()
 
-			// Acquire semaphore slot
-			fs.sem <- struct{}{}
-			defer func() { <-fs.sem }()
+			// NOTE: do NOT acquire fs.sem here. DownloadFileFromInfo ->
+			// DownloadFileWithInfoRetry already acquires a slot for the actual
+			// transfer. Acquiring here too made every download hold TWO slots,
+			// which both halved effective concurrency and could deadlock (with a
+			// pool of N, N goroutines holding the outer slot would all block
+			// forever on the inner acquire). The inner semaphore is the real
+			// concurrency bound; excess goroutines simply park on it.
 
 			debug.Info("Starting download for file: %s", file.Name)
 			fileInfo := &FileInfo{

--- a/backend/db/migrations/20260717120000_add_loopback.down.sql
+++ b/backend/db/migrations/20260717120000_add_loopback.down.sql
@@ -1,0 +1,11 @@
+-- Revert the loopback feature (GH #64).
+
+DELETE FROM system_settings WHERE key = 'loopback_max_rounds';
+
+DROP TABLE IF EXISTS loopback_session_plaintexts;
+DROP TABLE IF EXISTS loopback_session_jobs;
+DROP TRIGGER IF EXISTS update_loopback_sessions_updated_at ON loopback_sessions;
+DROP TABLE IF EXISTS loopback_sessions;
+
+ALTER TABLE job_workflow_steps DROP COLUMN IF EXISTS loopback_enabled;
+ALTER TABLE job_workflows DROP COLUMN IF EXISTS loopback_all_eligible;

--- a/backend/db/migrations/20260717120000_add_loopback.up.sql
+++ b/backend/db/migrations/20260717120000_add_loopback.up.sql
@@ -1,0 +1,90 @@
+-- Loopback feature (GH #64).
+--
+-- A "loopback" re-runs the *mutating* part of an attack (rules, or a hybrid mask)
+-- against ONLY the newly-cracked plaintexts (the delta), repeating until a round
+-- produces no new plaintext. It is orchestrated by a durable controller so a
+-- waiting session survives a backend restart (unlike the transient 'preparing'
+-- job state, which is failed on restart).
+--
+-- Config lives on the workflow / at job-start time, never on the preset definition:
+--   * job_workflows.loopback_all_eligible  master toggle: loopback every eligible
+--     step. When true, the per-step flags are ignored.
+--   * job_workflow_steps.loopback_enabled  per-step toggle (used only when the
+--     workflow master toggle is off).
+-- Standalone preset/custom runs carry the toggle in the create-job request.
+
+ALTER TABLE job_workflows
+    ADD COLUMN IF NOT EXISTS loopback_all_eligible BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE job_workflow_steps
+    ADD COLUMN IF NOT EXISTS loopback_enabled BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- One row per loopback "session": a workflow run, or a standalone preset/custom run.
+CREATE TABLE IF NOT EXISTS loopback_sessions (
+    id                 UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    hashlist_id        BIGINT NOT NULL REFERENCES hashlists(id) ON DELETE CASCADE,
+    source_type        TEXT NOT NULL CHECK (source_type IN ('workflow', 'preset', 'custom')),
+    source_workflow_id UUID REFERENCES job_workflows(id) ON DELETE SET NULL,
+    name               TEXT NOT NULL,
+    status             TEXT NOT NULL DEFAULT 'waiting'
+                         CHECK (status IN ('waiting', 'active', 'completed', 'failed', 'cancelled')),
+    current_round      INTEGER NOT NULL DEFAULT 0,
+    max_rounds         INTEGER NOT NULL DEFAULT 10,
+    error_message      TEXT,
+    created_by         UUID REFERENCES users(id),
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Only 'waiting'/'active' sessions need monitoring; a partial index keeps the
+-- monitor's idle-gate (EXISTS active session) cheap.
+CREATE INDEX IF NOT EXISTS idx_loopback_sessions_active
+    ON loopback_sessions(status) WHERE status IN ('waiting', 'active');
+CREATE INDEX IF NOT EXISTS idx_loopback_sessions_hashlist
+    ON loopback_sessions(hashlist_id);
+
+CREATE TRIGGER update_loopback_sessions_updated_at
+BEFORE UPDATE ON loopback_sessions
+FOR EACH ROW
+EXECUTE FUNCTION update_updated_at_column();
+
+-- Links each job_execution that belongs to a session, per round.
+--   round 0       = the original jobs (created by the normal create-job flow)
+--   round >= 1    = re-run jobs the controller spawns against the delta
+--   role          = 'original' | 'rerun'
+--   is_mutatable  = TRUE if this job's attack is re-run against the delta
+--                   (straight+rules, hybrid 6/7); FALSE otherwise (bruteforce,
+--                   wordlist-only, association) — those only feed the delta pool
+--   origin_job_id = the round-0 job this lineage descends from (NULL on originals)
+CREATE TABLE IF NOT EXISTS loopback_session_jobs (
+    id               BIGSERIAL PRIMARY KEY,
+    session_id       UUID NOT NULL REFERENCES loopback_sessions(id) ON DELETE CASCADE,
+    job_execution_id UUID NOT NULL REFERENCES job_executions(id) ON DELETE CASCADE,
+    round            INTEGER NOT NULL,
+    role             TEXT NOT NULL CHECK (role IN ('original', 'rerun')),
+    is_mutatable     BOOLEAN NOT NULL DEFAULT FALSE,
+    origin_job_id    UUID REFERENCES job_executions(id) ON DELETE SET NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (session_id, job_execution_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_loopback_session_jobs_session
+    ON loopback_session_jobs(session_id);
+CREATE INDEX IF NOT EXISTS idx_loopback_session_jobs_job
+    ON loopback_session_jobs(job_execution_id);
+
+-- Guard set of plaintexts already fed as loopback input for a session (md5 of the
+-- plaintext to stay compact). Guarantees each distinct plaintext is used exactly
+-- once, so the loop terminates and re-runs never repeat already-tried candidates.
+CREATE TABLE IF NOT EXISTS loopback_session_plaintexts (
+    session_id    UUID NOT NULL REFERENCES loopback_sessions(id) ON DELETE CASCADE,
+    plaintext_md5 TEXT NOT NULL,
+    PRIMARY KEY (session_id, plaintext_md5)
+);
+
+-- Admin-configurable safety cap on how many delta rounds a loopback session runs.
+INSERT INTO system_settings (key, value, description, data_type) VALUES
+    ('loopback_max_rounds', '10',
+     'Safety cap on how many delta rounds a loopback session runs before it stops, even if new cracks keep appearing. Applied when a session is created.',
+     'integer')
+ON CONFLICT (key) DO NOTHING;

--- a/backend/internal/handlers/jobs/user_jobs.go
+++ b/backend/internal/handlers/jobs/user_jobs.go
@@ -43,6 +43,7 @@ type UserJobsHandler struct {
 	teamService           *services.TeamService
 	charsetRepo           repository.CustomCharsetRepository
 	benchmarkRepo         *repository.BenchmarkRepository
+	loopbackService       *services.LoopbackService
 	wsHandler             WSHandler
 }
 
@@ -78,6 +79,7 @@ func NewUserJobsHandler(
 	teamService *services.TeamService,
 	charsetRepo repository.CustomCharsetRepository,
 	benchmarkRepo *repository.BenchmarkRepository,
+	loopbackService *services.LoopbackService,
 ) *UserJobsHandler {
 	return &UserJobsHandler{
 		jobExecRepo:           jobExecRepo,
@@ -100,6 +102,7 @@ func NewUserJobsHandler(
 		teamService:           teamService,
 		charsetRepo:           charsetRepo,
 		benchmarkRepo:         benchmarkRepo,
+		loopbackService:       loopbackService,
 		wsHandler:             nil, // Will be set later via SetWSHandler
 	}
 }
@@ -113,23 +116,23 @@ func (h *UserJobsHandler) JobExecutionService() *services.JobExecutionService {
 
 // JobSummary represents a job summary for the UI
 type JobSummary struct {
-	ID                     string  `json:"id"`
-	Name                   string  `json:"name"`
-	HashlistID             int64   `json:"hashlist_id"`
-	HashlistName           string  `json:"hashlist_name"`
-	PresetJobName          *string `json:"preset_job_name,omitempty"`
-	Status                 string  `json:"status"`
-	Priority               int     `json:"priority"`
-	MaxAgents              int     `json:"max_agents"`
-	DispatchedPercent      float64 `json:"dispatched_percent"`
-	SearchedPercent        float64 `json:"searched_percent"`
-	CrackedCount           int     `json:"cracked_count"`
-	AgentCount             int     `json:"agent_count"`
-	TotalSpeed             int64   `json:"total_speed"`
-	CreatedAt              string  `json:"created_at"`
-	UpdatedAt              string  `json:"updated_at"`
-	CompletedAt            *string `json:"completed_at,omitempty"`
-	CreatedByUsername      *string `json:"created_by_username,omitempty"`
+	ID                     string         `json:"id"`
+	Name                   string         `json:"name"`
+	HashlistID             int64          `json:"hashlist_id"`
+	HashlistName           string         `json:"hashlist_name"`
+	PresetJobName          *string        `json:"preset_job_name,omitempty"`
+	Status                 string         `json:"status"`
+	Priority               int            `json:"priority"`
+	MaxAgents              int            `json:"max_agents"`
+	DispatchedPercent      float64        `json:"dispatched_percent"`
+	SearchedPercent        float64        `json:"searched_percent"`
+	CrackedCount           int            `json:"cracked_count"`
+	AgentCount             int            `json:"agent_count"`
+	TotalSpeed             int64          `json:"total_speed"`
+	CreatedAt              string         `json:"created_at"`
+	UpdatedAt              string         `json:"updated_at"`
+	CompletedAt            *string        `json:"completed_at,omitempty"`
+	CreatedByUsername      *string        `json:"created_by_username,omitempty"`
 	ErrorMessage           *string        `json:"error_message,omitempty"`
 	EffectiveKeyspace      *models.BigInt `json:"effective_keyspace,omitempty"`
 	MultiplicationFactor   int64          `json:"multiplication_factor,omitempty"`
@@ -612,6 +615,67 @@ func truncateJobName(name string, hashMode string, maxLen int) string {
 	return prefix + suffix
 }
 
+// startLoopbackSession registers a loopback session for a batch of just-created jobs
+// (GH #64). It is a no-op unless at least one origin is a mutatable attack, so callers
+// can invoke it unconditionally. Failures are logged, never fatal — the jobs themselves
+// were already created.
+func (h *UserJobsHandler) startLoopbackSession(ctx context.Context, hashlistID int64, sourceType models.LoopbackSourceType, workflowID *uuid.UUID, name string, createdBy *uuid.UUID, origins []services.LoopbackOrigin) {
+	if h.loopbackService == nil || len(origins) == 0 {
+		return
+	}
+	hasMutatable := false
+	for _, o := range origins {
+		if o.IsMutatable {
+			hasMutatable = true
+			break
+		}
+	}
+	if !hasMutatable {
+		debug.Info("Loopback requested for hashlist %d but no mutatable jobs in the submission; skipping session", hashlistID)
+		return
+	}
+	if name == "" {
+		name = string(sourceType) + " loopback"
+	}
+	if _, err := h.loopbackService.CreateSession(ctx, hashlistID, sourceType, workflowID, name, createdBy, origins); err != nil {
+		debug.Error("Failed to create loopback session for hashlist %d: %v", hashlistID, err)
+	}
+}
+
+// ListLoopbackSessions handles GET /loopback-sessions — the "Pending Loopback" list
+// (GH #64). Non-admins see only their own sessions; admins see all.
+func (h *UserJobsHandler) ListLoopbackSessions(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	w.Header().Set("Content-Type", "application/json")
+	if h.loopbackService == nil {
+		json.NewEncoder(w).Encode([]interface{}{})
+		return
+	}
+
+	userRole, _ := ctx.Value("user_role").(string)
+	var createdBy *uuid.UUID
+	if userRole != "admin" {
+		userIDStr, _ := ctx.Value("user_id").(string)
+		uid, err := uuid.Parse(userIDStr)
+		if err != nil {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		createdBy = &uid
+	}
+
+	sessions, err := h.loopbackService.ListSessions(ctx, createdBy)
+	if err != nil {
+		debug.Error("Failed to list loopback sessions: %v", err)
+		http.Error(w, "Failed to list loopback sessions", http.StatusInternalServerError)
+		return
+	}
+	if sessions == nil {
+		sessions = []*models.LoopbackSession{}
+	}
+	json.NewEncoder(w).Encode(sessions)
+}
+
 // CreateJobFromHashlist handles POST /api/hashlists/{id}/create-job
 func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -681,11 +745,16 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 			Type          string   `json:"type"`
 			PresetJobIDs  []string `json:"preset_job_ids"`
 			CustomJobName string   `json:"custom_job_name"`
+			// Loopback, when true, runs the selected preset job(s) then re-runs the
+			// mutatable ones against only the newly-cracked plaintexts until dry (GH #64).
+			Loopback bool `json:"loopback"`
 		}
 		if err := json.Unmarshal(rawReq, &req); err != nil {
 			http.Error(w, "Invalid preset job request", http.StatusBadRequest)
 			return
 		}
+
+		var loopbackOrigins []services.LoopbackOrigin
 
 		// Create a job execution for each selected preset job
 		for _, presetJobIDStr := range req.PresetJobIDs {
@@ -728,6 +797,16 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 			}
 
 			createdJobs = append(createdJobs, jobExecution.ID.String())
+			if req.Loopback {
+				loopbackOrigins = append(loopbackOrigins, services.LoopbackOrigin{
+					JobExecutionID: jobExecution.ID,
+					IsMutatable:    models.IsMutatableAttack(presetJob.AttackMode, presetJob.RuleIDs),
+				})
+			}
+		}
+
+		if req.Loopback {
+			h.startLoopbackSession(ctx, hashlistID, models.LoopbackSourcePreset, nil, req.CustomJobName, &userID, loopbackOrigins)
 		}
 
 	case "workflow":
@@ -750,12 +829,17 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 				continue
 			}
 
-			// Get workflow steps
-			steps, err := h.workflowRepo.GetWorkflowSteps(ctx, workflowID)
+			// Get the workflow (loopback config) and its steps.
+			workflow, err := h.workflowRepo.GetWorkflowByID(ctx, workflowID)
 			if err != nil {
-				debug.Error("Failed to get workflow steps for %s: %v", workflowID, err)
+				debug.Error("Failed to get workflow %s: %v", workflowID, err)
 				continue
 			}
+			steps := workflow.Steps
+
+			// Loopback origins: every step's job is a member (so its cracks feed the
+			// delta pool), but only loopback-configured eligible steps are re-run (GH #64).
+			var loopbackOrigins []services.LoopbackOrigin
 
 			// Create a job for each step in order
 			for _, step := range steps {
@@ -792,7 +876,18 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 				}
 
 				createdJobs = append(createdJobs, jobExecution.ID.String())
+
+				stepLoopback := workflow.LoopbackAllEligible || step.LoopbackEnabled
+				loopbackOrigins = append(loopbackOrigins, services.LoopbackOrigin{
+					JobExecutionID: jobExecution.ID,
+					IsMutatable:    stepLoopback && models.IsMutatableAttack(presetJob.AttackMode, presetJob.RuleIDs),
+				})
 			}
+
+			// startLoopbackSession is a no-op unless at least one step is a mutatable
+			// loopback participant, so non-loopback workflows create no session.
+			wfID := workflowID
+			h.startLoopbackSession(ctx, hashlistID, models.LoopbackSourceWorkflow, &wfID, workflow.Name, &userID, loopbackOrigins)
 		}
 
 	case "custom":
@@ -822,6 +917,9 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 				// Filter, when present, generates an ephemeral filtered wordlist
 				// from the selected wordlist(s) for this job only (GH #40).
 				Filter *models.WordlistFilter `json:"filter"`
+				// Loopback, when true, re-runs this attack's mutation against only the
+				// newly-cracked plaintexts until dry (GH #64). Not combined with Filter.
+				Loopback bool `json:"loopback"`
 			} `json:"custom_job"`
 		}
 		if err := json.Unmarshal(rawReq, &req); err != nil {
@@ -1066,6 +1164,13 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 		}
 
 		createdJobs = append(createdJobs, jobExecution.ID.String())
+
+		if req.CustomJob.Loopback {
+			h.startLoopbackSession(ctx, hashlistID, models.LoopbackSourceCustom, nil, req.CustomJobName, &userID, []services.LoopbackOrigin{{
+				JobExecutionID: jobExecution.ID,
+				IsMutatable:    models.IsMutatableAttack(config.AttackMode, config.RuleIDs),
+			}})
+		}
 
 	default:
 		http.Error(w, "Invalid job type", http.StatusBadRequest)

--- a/backend/internal/models/jobs.go
+++ b/backend/internal/models/jobs.go
@@ -170,6 +170,11 @@ type JobWorkflow struct {
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	UpdatedAt time.Time `json:"updated_at" db:"updated_at"`
 
+	// LoopbackAllEligible is the workflow-level master loopback toggle (GH #64). When
+	// true, every eligible step is looped back against the delta and the per-step
+	// LoopbackEnabled flags are ignored.
+	LoopbackAllEligible bool `json:"loopback_all_eligible" db:"loopback_all_eligible"`
+
 	// Populated field holding the ordered steps
 	Steps []JobWorkflowStep `json:"steps,omitempty"`
 }
@@ -181,6 +186,11 @@ type JobWorkflowStep struct {
 	JobWorkflowID uuid.UUID `json:"job_workflow_id" db:"job_workflow_id"`
 	PresetJobID   uuid.UUID `json:"preset_job_id" db:"preset_job_id"`
 	StepOrder     int       `json:"step_order" db:"step_order"`
+
+	// LoopbackEnabled is the per-step loopback toggle (GH #64). Used only when the
+	// workflow's LoopbackAllEligible master toggle is off. A step is only actually
+	// looped back if its preset's attack is eligible (see IsMutatableAttack).
+	LoopbackEnabled bool `json:"loopback_enabled" db:"loopback_enabled"`
 
 	// Fields potentially populated by JOINs with preset_jobs
 	PresetJobName          string     `json:"preset_job_name,omitempty" db:"preset_job_name"`
@@ -195,9 +205,11 @@ type JobWorkflowStep struct {
 // PresetJobBasic represents minimal information about a preset job
 // Used for dropdowns and selection interfaces
 type PresetJobBasic struct {
-	ID                        uuid.UUID `json:"id" db:"id"`
-	Name                      string    `json:"name" db:"name"`
-	AllowHighPriorityOverride bool      `json:"allow_high_priority_override" db:"allow_high_priority_override"`
+	ID                        uuid.UUID  `json:"id" db:"id"`
+	Name                      string     `json:"name" db:"name"`
+	AllowHighPriorityOverride bool       `json:"allow_high_priority_override" db:"allow_high_priority_override"`
+	AttackMode                AttackMode `json:"attack_mode" db:"attack_mode"` // For loopback eligibility (GH #64)
+	RuleIDs                   IDArray    `json:"rule_ids" db:"rule_ids"`       // For loopback eligibility (GH #64)
 }
 
 // JobExecutionStatus represents the status of a job execution
@@ -630,6 +642,12 @@ type JobIncrementLayer struct {
 	ProcessedKeyspace    BigInt  `json:"processed_keyspace" db:"processed_keyspace"`       // Sum from tasks (NUMERIC)
 	DispatchedKeyspace   BigInt  `json:"dispatched_keyspace" db:"dispatched_keyspace"`     // Total keyspace dispatched (NUMERIC)
 	IsAccurateKeyspace   bool    `json:"is_accurate_keyspace" db:"is_accurate_keyspace"`   // TRUE after benchmark
+
+	// ProcessedBaseKeyspace is an in-memory, per-calculation aggregate of BASE-unit
+	// keyspace processed across this layer's tasks. It is NOT persisted (db:"-") — it
+	// exists so calculateIncrementJobProgress can compute a base-driven, structurally
+	// <=100% progress percentage that matches the regular (non-increment) job path.
+	ProcessedBaseKeyspace int64 `json:"-" db:"-"`
 
 	// Progress tracking
 	OverallProgressPercent float64    `json:"overall_progress_percent" db:"overall_progress_percent"`

--- a/backend/internal/models/loopback.go
+++ b/backend/internal/models/loopback.go
@@ -1,0 +1,101 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// LoopbackSessionStatus is the lifecycle state of a loopback session.
+type LoopbackSessionStatus string
+
+const (
+	// LoopbackSessionStatusWaiting: round-0 jobs are still running; the controller
+	// is waiting for them to reach a terminal state before the first delta round.
+	LoopbackSessionStatusWaiting LoopbackSessionStatus = "waiting"
+	// LoopbackSessionStatusActive: at least one delta round has been spawned and the
+	// controller is monitoring the current round's re-runs.
+	LoopbackSessionStatusActive LoopbackSessionStatus = "active"
+	// LoopbackSessionStatusCompleted: a round produced no new plaintext (dry), or the
+	// max-rounds cap was reached.
+	LoopbackSessionStatusCompleted LoopbackSessionStatus = "completed"
+	LoopbackSessionStatusFailed    LoopbackSessionStatus = "failed"
+	LoopbackSessionStatusCancelled LoopbackSessionStatus = "cancelled"
+)
+
+// LoopbackSourceType records how a session was started.
+type LoopbackSourceType string
+
+const (
+	LoopbackSourceWorkflow LoopbackSourceType = "workflow"
+	LoopbackSourcePreset   LoopbackSourceType = "preset"
+	LoopbackSourceCustom   LoopbackSourceType = "custom"
+)
+
+// LoopbackJobRole distinguishes a round-0 original job from a controller-spawned re-run.
+type LoopbackJobRole string
+
+const (
+	LoopbackJobRoleOriginal LoopbackJobRole = "original"
+	LoopbackJobRoleRerun    LoopbackJobRole = "rerun"
+)
+
+// LoopbackSession is the durable controller for one loopback group: a workflow run
+// or a standalone preset/custom run. It survives a backend restart so a session that
+// is waiting on long-running round-0 jobs is not lost.
+type LoopbackSession struct {
+	ID               uuid.UUID             `json:"id" db:"id"`
+	HashlistID       int64                 `json:"hashlist_id" db:"hashlist_id"`
+	SourceType       LoopbackSourceType    `json:"source_type" db:"source_type"`
+	SourceWorkflowID *uuid.UUID            `json:"source_workflow_id,omitempty" db:"source_workflow_id"`
+	Name             string                `json:"name" db:"name"`
+	Status           LoopbackSessionStatus `json:"status" db:"status"`
+	CurrentRound     int                   `json:"current_round" db:"current_round"`
+	MaxRounds        int                   `json:"max_rounds" db:"max_rounds"`
+	ErrorMessage     *string               `json:"error_message,omitempty" db:"error_message"`
+	CreatedBy        *uuid.UUID            `json:"created_by,omitempty" db:"created_by"`
+	CreatedAt        time.Time             `json:"created_at" db:"created_at"`
+	UpdatedAt        time.Time             `json:"updated_at" db:"updated_at"`
+
+	// Populated by joins for the "Pending Loopback" UI (not persisted directly).
+	Jobs []LoopbackSessionJob `json:"jobs,omitempty"`
+}
+
+// LoopbackSessionJob links a job_execution to a session at a specific round.
+type LoopbackSessionJob struct {
+	ID             int64           `json:"id" db:"id"`
+	SessionID      uuid.UUID       `json:"session_id" db:"session_id"`
+	JobExecutionID uuid.UUID       `json:"job_execution_id" db:"job_execution_id"`
+	Round          int             `json:"round" db:"round"`
+	Role           LoopbackJobRole `json:"role" db:"role"`
+	IsMutatable    bool            `json:"is_mutatable" db:"is_mutatable"`
+	OriginJobID    *uuid.UUID      `json:"origin_job_id,omitempty" db:"origin_job_id"`
+	CreatedAt      time.Time       `json:"created_at" db:"created_at"`
+
+	// Fields populated by a join with job_executions for UI rendering.
+	JobName   string             `json:"job_name,omitempty" db:"job_name"`
+	JobStatus JobExecutionStatus `json:"job_status,omitempty" db:"job_status"`
+}
+
+// IsMutatableAttack reports whether an attack config's mutating part can be re-run
+// against a delta wordlist. Only wordlist-consuming modes whose *mutation* is
+// separable from the wordlist qualify:
+//   - Straight (0) WITH rules  → the rules are the mutation (delta × rules)
+//   - Hybrid (6/7)             → the mask is the mutation (delta ± mask)
+//
+// Ineligible (return false), and therefore only feed the delta pool with their cracks:
+//   - Straight (0) with NO rules → nothing mutates; the word was already tried as-is
+//   - Brute-force (3)            → no wordlist to swap the delta into
+//   - Combination (1)            → no clean "which side is the mutation" (each side can
+//     carry its own rules); also not offered as a preset/custom attack here
+//   - Association (9)            → 1:1 wordlist mapping, no loopback semantics
+func IsMutatableAttack(mode AttackMode, ruleIDs IDArray) bool {
+	switch mode {
+	case AttackModeStraight:
+		return len(ruleIDs) > 0
+	case AttackModeHybridWordlistMask, AttackModeHybridMaskWordlist:
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/internal/repository/job_execution_repository_extension.go
+++ b/backend/internal/repository/job_execution_repository_extension.go
@@ -23,7 +23,7 @@ func (r *JobExecutionRepository) ListWithPagination(ctx context.Context, limit, 
 				WHEN status IN ('preparing', 'pending', 'running', 'paused') THEN 0
 				ELSE 1
 			END,
-			-- Within active jobs: by priority DESC, created_at DESC (newest first within tier)
+			-- Within active jobs: by priority DESC, created_at ASC (FIFO: oldest first, matching scheduler run order)
 			CASE
 				WHEN status IN ('preparing', 'pending', 'running', 'paused') THEN priority
 				ELSE NULL
@@ -31,7 +31,7 @@ func (r *JobExecutionRepository) ListWithPagination(ctx context.Context, limit, 
 			CASE
 				WHEN status IN ('preparing', 'pending', 'running', 'paused') THEN created_at
 				ELSE NULL
-			END DESC,
+			END ASC,
 			-- Within completed jobs: by completed_at DESC (most recent first)
 			-- Use COALESCE to handle NULL completed_at (fallback to updated_at, then created_at)
 			CASE
@@ -140,7 +140,7 @@ func (r *JobExecutionRepository) ListWithFilters(ctx context.Context, limit, off
 			WHEN je.status IN ('preparing', 'pending', 'running', 'paused') THEN 0
 			ELSE 1
 		END,
-		-- Within active jobs: by priority DESC, created_at DESC (newest first within tier)
+		-- Within active jobs: by priority DESC, created_at ASC (FIFO: oldest first, matching scheduler run order)
 		CASE
 			WHEN je.status IN ('preparing', 'pending', 'running', 'paused') THEN je.priority
 			ELSE NULL
@@ -148,7 +148,7 @@ func (r *JobExecutionRepository) ListWithFilters(ctx context.Context, limit, off
 		CASE
 			WHEN je.status IN ('preparing', 'pending', 'running', 'paused') THEN je.created_at
 			ELSE NULL
-		END DESC,
+		END ASC,
 		-- Within completed jobs: by completed_at DESC (most recent first)
 		-- Use COALESCE to handle NULL completed_at (fallback to updated_at, then created_at)
 		CASE
@@ -631,7 +631,7 @@ func (r *JobExecutionRepository) ListWithFiltersAndUser(ctx context.Context, lim
 			WHEN je.status IN ('preparing', 'pending', 'running', 'paused') THEN 0
 			ELSE 1
 		END,
-		-- Within active jobs: by priority DESC, created_at DESC (newest first within tier)
+		-- Within active jobs: by priority DESC, created_at ASC (FIFO: oldest first, matching scheduler run order)
 		CASE
 			WHEN je.status IN ('preparing', 'pending', 'running', 'paused') THEN je.priority
 			ELSE NULL
@@ -639,7 +639,7 @@ func (r *JobExecutionRepository) ListWithFiltersAndUser(ctx context.Context, lim
 		CASE
 			WHEN je.status IN ('preparing', 'pending', 'running', 'paused') THEN je.created_at
 			ELSE NULL
-		END DESC,
+		END ASC,
 		-- Within completed jobs: by completed_at DESC (most recent first)
 		-- Use COALESCE to handle NULL completed_at (fallback to updated_at, then created_at)
 		CASE

--- a/backend/internal/repository/job_execution_repository_updates.go
+++ b/backend/internal/repository/job_execution_repository_updates.go
@@ -64,7 +64,7 @@ func (r *JobExecutionRepository) GetJobsByWordlistID(ctx context.Context, wordli
 			base_keyspace, effective_keyspace, multiplication_factor,
 			overall_progress_percent,
 			dispatched_keyspace, chunk_size_seconds, rule_ids,
-			wordlist_ids
+			wordlist_ids, COALESCE(increment_mode, '')
 		FROM job_executions
 		WHERE wordlist_ids @> to_jsonb(ARRAY[$1::text]) AND status IN ('pending', 'running', 'paused')`
 
@@ -85,7 +85,7 @@ func (r *JobExecutionRepository) GetJobsByWordlistID(ctx context.Context, wordli
 			&job.BaseKeyspace, &job.EffectiveKeyspace,
 			&job.MultiplicationFactor,
 			&job.OverallProgressPercent, &job.DispatchedKeyspace, &job.ChunkSizeSeconds,
-			&job.RuleIDs, &job.WordlistIDs,
+			&job.RuleIDs, &job.WordlistIDs, &job.IncrementMode,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan job execution: %w", err)

--- a/backend/internal/repository/job_workflow_repository.go
+++ b/backend/internal/repository/job_workflow_repository.go
@@ -13,14 +13,14 @@ import (
 
 // JobWorkflowRepository defines the interface for interacting with job workflows and steps.
 type JobWorkflowRepository interface {
-	CreateWorkflow(ctx context.Context, name string) (*models.JobWorkflow, error)
+	CreateWorkflow(ctx context.Context, name string, loopbackAllEligible bool) (*models.JobWorkflow, error)
 	GetWorkflowByID(ctx context.Context, id uuid.UUID) (*models.JobWorkflow, error)
 	GetWorkflowByName(ctx context.Context, name string) (*models.JobWorkflow, error)
 	ListWorkflows(ctx context.Context) ([]models.JobWorkflow, error)
-	UpdateWorkflow(ctx context.Context, id uuid.UUID, name string) (*models.JobWorkflow, error)
+	UpdateWorkflow(ctx context.Context, id uuid.UUID, name string, loopbackAllEligible bool) (*models.JobWorkflow, error)
 	DeleteWorkflow(ctx context.Context, id uuid.UUID) error
 
-	CreateWorkflowStep(ctx context.Context, workflowID, presetJobID uuid.UUID, stepOrder int) (*models.JobWorkflowStep, error)
+	CreateWorkflowStep(ctx context.Context, workflowID, presetJobID uuid.UUID, stepOrder int, loopbackEnabled bool) (*models.JobWorkflowStep, error)
 	GetWorkflowSteps(ctx context.Context, workflowID uuid.UUID) ([]models.JobWorkflowStep, error)
 	DeleteWorkflowSteps(ctx context.Context, workflowID uuid.UUID) error
 	CheckPresetJobsExist(ctx context.Context, ids []uuid.UUID) ([]uuid.UUID, error)
@@ -47,12 +47,12 @@ func NewJobWorkflowRepository(db *sql.DB) JobWorkflowRepository {
 }
 
 // CreateWorkflow inserts a new job workflow.
-func (r *jobWorkflowRepository) CreateWorkflow(ctx context.Context, name string) (*models.JobWorkflow, error) {
-	query := `INSERT INTO job_workflows (name) VALUES ($1) RETURNING id, name, created_at, updated_at`
-	row := r.db.QueryRowContext(ctx, query, name)
+func (r *jobWorkflowRepository) CreateWorkflow(ctx context.Context, name string, loopbackAllEligible bool) (*models.JobWorkflow, error) {
+	query := `INSERT INTO job_workflows (name, loopback_all_eligible) VALUES ($1, $2) RETURNING id, name, loopback_all_eligible, created_at, updated_at`
+	row := r.db.QueryRowContext(ctx, query, name, loopbackAllEligible)
 
 	var wf models.JobWorkflow
-	err := row.Scan(&wf.ID, &wf.Name, &wf.CreatedAt, &wf.UpdatedAt)
+	err := row.Scan(&wf.ID, &wf.Name, &wf.LoopbackAllEligible, &wf.CreatedAt, &wf.UpdatedAt)
 	if err != nil {
 		// TODO: Handle potential unique constraint violation error (e.g., convert pq error)
 		debug.Error("Error creating job workflow: %v", err)
@@ -63,11 +63,11 @@ func (r *jobWorkflowRepository) CreateWorkflow(ctx context.Context, name string)
 
 // GetWorkflowByID retrieves a job workflow by ID, including its steps.
 func (r *jobWorkflowRepository) GetWorkflowByID(ctx context.Context, id uuid.UUID) (*models.JobWorkflow, error) {
-	query := `SELECT id, name, created_at, updated_at FROM job_workflows WHERE id = $1 LIMIT 1`
+	query := `SELECT id, name, loopback_all_eligible, created_at, updated_at FROM job_workflows WHERE id = $1 LIMIT 1`
 	row := r.db.QueryRowContext(ctx, query, id)
 
 	var wf models.JobWorkflow
-	err := row.Scan(&wf.ID, &wf.Name, &wf.CreatedAt, &wf.UpdatedAt)
+	err := row.Scan(&wf.ID, &wf.Name, &wf.LoopbackAllEligible, &wf.CreatedAt, &wf.UpdatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, fmt.Errorf("job workflow not found: %w", ErrNotFound)
@@ -90,11 +90,11 @@ func (r *jobWorkflowRepository) GetWorkflowByID(ctx context.Context, id uuid.UUI
 
 // GetWorkflowByName retrieves a job workflow by name.
 func (r *jobWorkflowRepository) GetWorkflowByName(ctx context.Context, name string) (*models.JobWorkflow, error) {
-	query := `SELECT id, name, created_at, updated_at FROM job_workflows WHERE name = $1 LIMIT 1`
+	query := `SELECT id, name, loopback_all_eligible, created_at, updated_at FROM job_workflows WHERE name = $1 LIMIT 1`
 	row := r.db.QueryRowContext(ctx, query, name)
 
 	var wf models.JobWorkflow
-	err := row.Scan(&wf.ID, &wf.Name, &wf.CreatedAt, &wf.UpdatedAt)
+	err := row.Scan(&wf.ID, &wf.Name, &wf.LoopbackAllEligible, &wf.CreatedAt, &wf.UpdatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, fmt.Errorf("job workflow not found: %w", ErrNotFound)
@@ -109,10 +109,10 @@ func (r *jobWorkflowRepository) GetWorkflowByName(ctx context.Context, name stri
 // ListWorkflows retrieves all job workflows.
 func (r *jobWorkflowRepository) ListWorkflows(ctx context.Context) ([]models.JobWorkflow, error) {
 	query := `
-		SELECT w.id, w.name, w.created_at, w.updated_at, COUNT(s.id) as step_count
+		SELECT w.id, w.name, w.loopback_all_eligible, w.created_at, w.updated_at, COUNT(s.id) as step_count
 		FROM job_workflows w
 		LEFT JOIN job_workflow_steps s ON w.id = s.job_workflow_id
-		GROUP BY w.id, w.name, w.created_at, w.updated_at
+		GROUP BY w.id, w.name, w.loopback_all_eligible, w.created_at, w.updated_at
 		ORDER BY w.name
 	` // TODO: Pagination
 	rows, err := r.db.QueryContext(ctx, query)
@@ -126,7 +126,7 @@ func (r *jobWorkflowRepository) ListWorkflows(ctx context.Context) ([]models.Job
 	for rows.Next() {
 		var wf models.JobWorkflow
 		var stepCount int
-		if err := rows.Scan(&wf.ID, &wf.Name, &wf.CreatedAt, &wf.UpdatedAt, &stepCount); err != nil {
+		if err := rows.Scan(&wf.ID, &wf.Name, &wf.LoopbackAllEligible, &wf.CreatedAt, &wf.UpdatedAt, &stepCount); err != nil {
 			debug.Error("Error scanning job workflow row: %v", err)
 			return nil, fmt.Errorf("error scanning job workflow row: %w", err)
 		}
@@ -146,12 +146,12 @@ func (r *jobWorkflowRepository) ListWorkflows(ctx context.Context) ([]models.Job
 }
 
 // UpdateWorkflow updates a job workflow's name.
-func (r *jobWorkflowRepository) UpdateWorkflow(ctx context.Context, id uuid.UUID, name string) (*models.JobWorkflow, error) {
-	query := `UPDATE job_workflows SET name = $2, updated_at = NOW() WHERE id = $1 RETURNING id, name, created_at, updated_at`
-	row := r.db.QueryRowContext(ctx, query, id, name)
+func (r *jobWorkflowRepository) UpdateWorkflow(ctx context.Context, id uuid.UUID, name string, loopbackAllEligible bool) (*models.JobWorkflow, error) {
+	query := `UPDATE job_workflows SET name = $2, loopback_all_eligible = $3, updated_at = NOW() WHERE id = $1 RETURNING id, name, loopback_all_eligible, created_at, updated_at`
+	row := r.db.QueryRowContext(ctx, query, id, name, loopbackAllEligible)
 
 	var wf models.JobWorkflow
-	err := row.Scan(&wf.ID, &wf.Name, &wf.CreatedAt, &wf.UpdatedAt)
+	err := row.Scan(&wf.ID, &wf.Name, &wf.LoopbackAllEligible, &wf.CreatedAt, &wf.UpdatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, fmt.Errorf("job workflow not found for update: %w", ErrNotFound)
@@ -183,15 +183,15 @@ func (r *jobWorkflowRepository) DeleteWorkflow(ctx context.Context, id uuid.UUID
 // --- Workflow Step Methods ---
 
 // CreateWorkflowStep inserts a single step for a workflow.
-func (r *jobWorkflowRepository) CreateWorkflowStep(ctx context.Context, workflowID, presetJobID uuid.UUID, stepOrder int) (*models.JobWorkflowStep, error) {
+func (r *jobWorkflowRepository) CreateWorkflowStep(ctx context.Context, workflowID, presetJobID uuid.UUID, stepOrder int, loopbackEnabled bool) (*models.JobWorkflowStep, error) {
 	query := `
-		INSERT INTO job_workflow_steps (job_workflow_id, preset_job_id, step_order)
-		VALUES ($1, $2, $3)
-		RETURNING id, job_workflow_id, preset_job_id, step_order`
-	row := r.db.QueryRowContext(ctx, query, workflowID, presetJobID, stepOrder)
+		INSERT INTO job_workflow_steps (job_workflow_id, preset_job_id, step_order, loopback_enabled)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, job_workflow_id, preset_job_id, step_order, loopback_enabled`
+	row := r.db.QueryRowContext(ctx, query, workflowID, presetJobID, stepOrder, loopbackEnabled)
 
 	var step models.JobWorkflowStep
-	err := row.Scan(&step.ID, &step.JobWorkflowID, &step.PresetJobID, &step.StepOrder)
+	err := row.Scan(&step.ID, &step.JobWorkflowID, &step.PresetJobID, &step.StepOrder, &step.LoopbackEnabled)
 	if err != nil {
 		// TODO: Handle potential unique constraint (workflowID, stepOrder) violation
 		// TODO: Handle potential foreign key constraint violation (presetJobID)
@@ -205,7 +205,7 @@ func (r *jobWorkflowRepository) CreateWorkflowStep(ctx context.Context, workflow
 func (r *jobWorkflowRepository) GetWorkflowSteps(ctx context.Context, workflowID uuid.UUID) ([]models.JobWorkflowStep, error) {
 	query := `
 		SELECT
-			jws.id, jws.job_workflow_id, jws.preset_job_id, jws.step_order,
+			jws.id, jws.job_workflow_id, jws.preset_job_id, jws.step_order, jws.loopback_enabled,
 			pj.name as preset_job_name,
 			pj.attack_mode as preset_job_attack_mode,
 			pj.priority as preset_job_priority,
@@ -229,7 +229,7 @@ func (r *jobWorkflowRepository) GetWorkflowSteps(ctx context.Context, workflowID
 	for rows.Next() {
 		var step models.JobWorkflowStep
 		if err := rows.Scan(
-			&step.ID, &step.JobWorkflowID, &step.PresetJobID, &step.StepOrder,
+			&step.ID, &step.JobWorkflowID, &step.PresetJobID, &step.StepOrder, &step.LoopbackEnabled,
 			&step.PresetJobName, &step.PresetJobAttackMode, &step.PresetJobPriority,
 			&step.PresetJobBinaryVersion, &step.PresetJobBinaryName, &step.PresetJobWordlistIDs, &step.PresetJobRuleIDs,
 		); err != nil {

--- a/backend/internal/repository/loopback_repository.go
+++ b/backend/internal/repository/loopback_repository.go
@@ -1,0 +1,410 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/ZerkerEOD/krakenhashes/backend/internal/db"
+	"github.com/ZerkerEOD/krakenhashes/backend/internal/models"
+	"github.com/ZerkerEOD/krakenhashes/backend/pkg/debug"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+)
+
+// LoopbackRepository persists loopback sessions (GH #64) and computes each round's
+// delta of newly-cracked plaintexts.
+type LoopbackRepository struct {
+	db *db.DB
+}
+
+// NewLoopbackRepository creates a new loopback repository.
+func NewLoopbackRepository(database *db.DB) *LoopbackRepository {
+	return &LoopbackRepository{db: database}
+}
+
+// terminalJobStatuses are the job_execution states that count as "finished" for the
+// purpose of deciding whether a loopback round is complete.
+const terminalJobStatusesSQL = "('completed', 'failed', 'cancelled')"
+
+// CreateSessionWithJobs inserts a session and links its round-0 jobs atomically, so the
+// monitor (which runs on another goroutine) never observes a session before its jobs are
+// linked — which would otherwise let it prematurely complete the session as "no jobs".
+func (r *LoopbackRepository) CreateSessionWithJobs(ctx context.Context, s *models.LoopbackSession, jobs []models.LoopbackSessionJob) error {
+	if s.Status == "" {
+		s.Status = models.LoopbackSessionStatusWaiting
+	}
+	if s.MaxRounds <= 0 {
+		s.MaxRounds = 10
+	}
+	var workflowID interface{}
+	if s.SourceWorkflowID != nil {
+		workflowID = *s.SourceWorkflowID
+	}
+	var createdBy interface{}
+	if s.CreatedBy != nil {
+		createdBy = *s.CreatedBy
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("error starting loopback session transaction: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	err = tx.QueryRowContext(ctx, `
+		INSERT INTO loopback_sessions (hashlist_id, source_type, source_workflow_id, name, status, current_round, max_rounds, created_by)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		RETURNING id, created_at, updated_at`,
+		s.HashlistID, s.SourceType, workflowID, s.Name, s.Status, s.CurrentRound, s.MaxRounds, createdBy,
+	).Scan(&s.ID, &s.CreatedAt, &s.UpdatedAt)
+	if err != nil {
+		debug.Error("Error creating loopback session: %v", err)
+		return fmt.Errorf("error creating loopback session: %w", err)
+	}
+
+	for i := range jobs {
+		var originJob interface{}
+		if jobs[i].OriginJobID != nil {
+			originJob = *jobs[i].OriginJobID
+		}
+		if _, err = tx.ExecContext(ctx, `
+			INSERT INTO loopback_session_jobs (session_id, job_execution_id, round, role, is_mutatable, origin_job_id)
+			VALUES ($1, $2, $3, $4, $5, $6)
+			ON CONFLICT (session_id, job_execution_id) DO NOTHING`,
+			s.ID, jobs[i].JobExecutionID, jobs[i].Round, jobs[i].Role, jobs[i].IsMutatable, originJob,
+		); err != nil {
+			return fmt.Errorf("error linking round-0 job to loopback session: %w", err)
+		}
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("error committing loopback session: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+// GetSession loads a single session by ID (without its jobs).
+func (r *LoopbackRepository) GetSession(ctx context.Context, id uuid.UUID) (*models.LoopbackSession, error) {
+	query := `
+		SELECT id, hashlist_id, source_type, source_workflow_id, name, status, current_round, max_rounds, error_message, created_by, created_at, updated_at
+		FROM loopback_sessions WHERE id = $1`
+	return r.scanSession(r.db.QueryRowContext(ctx, query, id))
+}
+
+// GetActiveSessions returns all sessions still being monitored (waiting or active).
+func (r *LoopbackRepository) GetActiveSessions(ctx context.Context) ([]*models.LoopbackSession, error) {
+	query := `
+		SELECT id, hashlist_id, source_type, source_workflow_id, name, status, current_round, max_rounds, error_message, created_by, created_at, updated_at
+		FROM loopback_sessions
+		WHERE status IN ('waiting', 'active')
+		ORDER BY created_at`
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("error listing active loopback sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var sessions []*models.LoopbackSession
+	for rows.Next() {
+		s, err := r.scanSessionRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		sessions = append(sessions, s)
+	}
+	return sessions, rows.Err()
+}
+
+// HasActiveSessions is the cheap idle-gate for the monitor: it avoids scanning job
+// states when there is no loopback work in flight.
+func (r *LoopbackRepository) HasActiveSessions(ctx context.Context) (bool, error) {
+	var exists bool
+	err := r.db.QueryRowContext(ctx,
+		`SELECT EXISTS (SELECT 1 FROM loopback_sessions WHERE status IN ('waiting', 'active'))`,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("error checking for active loopback sessions: %w", err)
+	}
+	return exists, nil
+}
+
+// ListSessionsByHashlist returns sessions for a hashlist (most recent first) for the UI.
+func (r *LoopbackRepository) ListSessionsByHashlist(ctx context.Context, hashlistID int64) ([]*models.LoopbackSession, error) {
+	query := `
+		SELECT id, hashlist_id, source_type, source_workflow_id, name, status, current_round, max_rounds, error_message, created_by, created_at, updated_at
+		FROM loopback_sessions
+		WHERE hashlist_id = $1
+		ORDER BY created_at DESC`
+	rows, err := r.db.QueryContext(ctx, query, hashlistID)
+	if err != nil {
+		return nil, fmt.Errorf("error listing loopback sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var sessions []*models.LoopbackSession
+	for rows.Next() {
+		s, err := r.scanSessionRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		sessions = append(sessions, s)
+	}
+	return sessions, rows.Err()
+}
+
+// ListSessions returns loopback sessions, optionally filtered to a single creator
+// (nil = all creators, for admins), most recent first, capped at limit.
+func (r *LoopbackRepository) ListSessions(ctx context.Context, createdBy *uuid.UUID, limit int) ([]*models.LoopbackSession, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	query := `
+		SELECT id, hashlist_id, source_type, source_workflow_id, name, status, current_round, max_rounds, error_message, created_by, created_at, updated_at
+		FROM loopback_sessions`
+	var rows *sql.Rows
+	var err error
+	if createdBy != nil {
+		query += ` WHERE created_by = $1 ORDER BY created_at DESC LIMIT $2`
+		rows, err = r.db.QueryContext(ctx, query, *createdBy, limit)
+	} else {
+		query += ` ORDER BY created_at DESC LIMIT $1`
+		rows, err = r.db.QueryContext(ctx, query, limit)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error listing loopback sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var sessions []*models.LoopbackSession
+	for rows.Next() {
+		s, err := r.scanSessionRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		sessions = append(sessions, s)
+	}
+	return sessions, rows.Err()
+}
+
+// UpdateSessionStatus updates a session's status, current round and error message.
+func (r *LoopbackRepository) UpdateSessionStatus(ctx context.Context, id uuid.UUID, status models.LoopbackSessionStatus, currentRound int, errMsg *string) error {
+	_, err := r.db.ExecContext(ctx,
+		`UPDATE loopback_sessions SET status = $2, current_round = $3, error_message = $4 WHERE id = $1`,
+		id, status, currentRound, errMsg,
+	)
+	if err != nil {
+		return fmt.Errorf("error updating loopback session %s: %w", id, err)
+	}
+	return nil
+}
+
+// AddSessionJob links a job_execution to a session at a specific round.
+func (r *LoopbackRepository) AddSessionJob(ctx context.Context, j *models.LoopbackSessionJob) error {
+	query := `
+		INSERT INTO loopback_session_jobs (session_id, job_execution_id, round, role, is_mutatable, origin_job_id)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (session_id, job_execution_id) DO NOTHING
+		RETURNING id, created_at`
+	var originJob interface{}
+	if j.OriginJobID != nil {
+		originJob = *j.OriginJobID
+	}
+	err := r.db.QueryRowContext(ctx, query,
+		j.SessionID, j.JobExecutionID, j.Round, j.Role, j.IsMutatable, originJob,
+	).Scan(&j.ID, &j.CreatedAt)
+	if err == sql.ErrNoRows {
+		// Row already existed (ON CONFLICT); not an error.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error adding loopback session job: %w", err)
+	}
+	return nil
+}
+
+// GetSessionJobs returns all jobs of a session with job name/status joined, for the UI.
+func (r *LoopbackRepository) GetSessionJobs(ctx context.Context, sessionID uuid.UUID) ([]models.LoopbackSessionJob, error) {
+	query := `
+		SELECT lsj.id, lsj.session_id, lsj.job_execution_id, lsj.round, lsj.role, lsj.is_mutatable, lsj.origin_job_id, lsj.created_at,
+		       je.name, je.status
+		FROM loopback_session_jobs lsj
+		JOIN job_executions je ON je.id = lsj.job_execution_id
+		WHERE lsj.session_id = $1
+		ORDER BY lsj.round, lsj.created_at`
+	rows, err := r.db.QueryContext(ctx, query, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("error getting loopback session jobs: %w", err)
+	}
+	defer rows.Close()
+
+	var jobs []models.LoopbackSessionJob
+	for rows.Next() {
+		var j models.LoopbackSessionJob
+		if err := rows.Scan(&j.ID, &j.SessionID, &j.JobExecutionID, &j.Round, &j.Role, &j.IsMutatable, &j.OriginJobID, &j.CreatedAt, &j.JobName, &j.JobStatus); err != nil {
+			return nil, fmt.Errorf("error scanning loopback session job: %w", err)
+		}
+		jobs = append(jobs, j)
+	}
+	return jobs, rows.Err()
+}
+
+// GetMutatableOriginJobs returns the round-0 jobs whose attack is looped back against
+// the delta. Their configs are the templates each round's re-runs are built from.
+func (r *LoopbackRepository) GetMutatableOriginJobs(ctx context.Context, sessionID uuid.UUID) ([]models.LoopbackSessionJob, error) {
+	query := `
+		SELECT id, session_id, job_execution_id, round, role, is_mutatable, origin_job_id, created_at
+		FROM loopback_session_jobs
+		WHERE session_id = $1 AND round = 0 AND is_mutatable = true
+		ORDER BY created_at`
+	rows, err := r.db.QueryContext(ctx, query, sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("error getting mutatable origin jobs: %w", err)
+	}
+	defer rows.Close()
+
+	var jobs []models.LoopbackSessionJob
+	for rows.Next() {
+		var j models.LoopbackSessionJob
+		if err := rows.Scan(&j.ID, &j.SessionID, &j.JobExecutionID, &j.Round, &j.Role, &j.IsMutatable, &j.OriginJobID, &j.CreatedAt); err != nil {
+			return nil, fmt.Errorf("error scanning mutatable origin job: %w", err)
+		}
+		jobs = append(jobs, j)
+	}
+	return jobs, rows.Err()
+}
+
+// CountNonTerminalRoundJobs returns how many of a round's jobs have not yet reached a
+// terminal state. A round is complete when this is zero.
+func (r *LoopbackRepository) CountNonTerminalRoundJobs(ctx context.Context, sessionID uuid.UUID, round int) (int, error) {
+	query := `
+		SELECT COUNT(*)
+		FROM loopback_session_jobs lsj
+		JOIN job_executions je ON je.id = lsj.job_execution_id
+		WHERE lsj.session_id = $1 AND lsj.round = $2
+		  AND je.status NOT IN ` + terminalJobStatusesSQL
+	var count int
+	if err := r.db.QueryRowContext(ctx, query, sessionID, round).Scan(&count); err != nil {
+		return 0, fmt.Errorf("error counting non-terminal round jobs: %w", err)
+	}
+	return count, nil
+}
+
+// CountRoundJobs returns how many jobs a round has (used to detect an empty round-0,
+// which means the workflow had no jobs to monitor).
+func (r *LoopbackRepository) CountRoundJobs(ctx context.Context, sessionID uuid.UUID, round int) (int, error) {
+	var count int
+	if err := r.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM loopback_session_jobs WHERE session_id = $1 AND round = $2`,
+		sessionID, round,
+	).Scan(&count); err != nil {
+		return 0, fmt.Errorf("error counting round jobs: %w", err)
+	}
+	return count, nil
+}
+
+// HashlistHasUncracked reports whether the hashlist still has any uncracked hash. When it
+// doesn't, there is nothing left for a further loopback round to crack, so the session can
+// complete immediately instead of spawning a wasted round. Backed by the partial index
+// idx_hashes_uncracked.
+func (r *LoopbackRepository) HashlistHasUncracked(ctx context.Context, hashlistID int64) (bool, error) {
+	var exists bool
+	err := r.db.QueryRowContext(ctx,
+		`SELECT EXISTS (
+			SELECT 1 FROM hashlist_hashes hh
+			JOIN hashes h ON h.id = hh.hash_id
+			WHERE hh.hashlist_id = $1 AND h.is_cracked = false
+		)`, hashlistID,
+	).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("error checking for uncracked hashes: %w", err)
+	}
+	return exists, nil
+}
+
+// GetNewDeltaPlaintexts returns the distinct plaintexts newly cracked by this session's
+// own jobs (attributed via hashes.cracked_by_task_id) on the session's hashlist that
+// have NOT already been used as loopback input. This is the delta for the next round.
+// Scoping to the session's tasks keeps unrelated concurrent jobs on the same hashlist
+// from bleeding into the loopback.
+func (r *LoopbackRepository) GetNewDeltaPlaintexts(ctx context.Context, sessionID uuid.UUID, hashlistID int64) ([]string, error) {
+	query := `
+		SELECT DISTINCT h.password
+		FROM hashes h
+		JOIN hashlist_hashes hh ON hh.hash_id = h.id
+		JOIN job_tasks jt ON jt.id = h.cracked_by_task_id
+		JOIN loopback_session_jobs lsj ON lsj.job_execution_id = jt.job_execution_id
+		WHERE lsj.session_id = $1
+		  AND hh.hashlist_id = $2
+		  AND h.is_cracked = true
+		  AND h.password IS NOT NULL
+		  AND h.password <> ''
+		  AND NOT EXISTS (
+		      SELECT 1 FROM loopback_session_plaintexts lsp
+		      WHERE lsp.session_id = $1 AND lsp.plaintext_md5 = md5(h.password)
+		  )`
+	rows, err := r.db.QueryContext(ctx, query, sessionID, hashlistID)
+	if err != nil {
+		return nil, fmt.Errorf("error computing loopback delta: %w", err)
+	}
+	defer rows.Close()
+
+	var plaintexts []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			return nil, fmt.Errorf("error scanning delta plaintext: %w", err)
+		}
+		plaintexts = append(plaintexts, p)
+	}
+	return plaintexts, rows.Err()
+}
+
+// MarkPlaintextsUsed records plaintexts as consumed loopback input for the session so a
+// later round never re-runs the same candidate. Idempotent.
+func (r *LoopbackRepository) MarkPlaintextsUsed(ctx context.Context, sessionID uuid.UUID, plaintexts []string) error {
+	if len(plaintexts) == 0 {
+		return nil
+	}
+	_, err := r.db.ExecContext(ctx,
+		`INSERT INTO loopback_session_plaintexts (session_id, plaintext_md5)
+		 SELECT $1, md5(p) FROM unnest($2::text[]) AS p
+		 ON CONFLICT DO NOTHING`,
+		sessionID, pq.Array(plaintexts),
+	)
+	if err != nil {
+		return fmt.Errorf("error marking loopback plaintexts used: %w", err)
+	}
+	return nil
+}
+
+// scanSession scans a single session row.
+func (r *LoopbackRepository) scanSession(row *sql.Row) (*models.LoopbackSession, error) {
+	var s models.LoopbackSession
+	err := row.Scan(&s.ID, &s.HashlistID, &s.SourceType, &s.SourceWorkflowID, &s.Name, &s.Status,
+		&s.CurrentRound, &s.MaxRounds, &s.ErrorMessage, &s.CreatedBy, &s.CreatedAt, &s.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error scanning loopback session: %w", err)
+	}
+	return &s, nil
+}
+
+// scanSessionRows scans a session from a multi-row result.
+func (r *LoopbackRepository) scanSessionRows(rows *sql.Rows) (*models.LoopbackSession, error) {
+	var s models.LoopbackSession
+	err := rows.Scan(&s.ID, &s.HashlistID, &s.SourceType, &s.SourceWorkflowID, &s.Name, &s.Status,
+		&s.CurrentRound, &s.MaxRounds, &s.ErrorMessage, &s.CreatedBy, &s.CreatedAt, &s.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("error scanning loopback session: %w", err)
+	}
+	return &s, nil
+}

--- a/backend/internal/routes/admin_jobs_handlers.go
+++ b/backend/internal/routes/admin_jobs_handlers.go
@@ -409,11 +409,18 @@ func (h *AdminJobsHandler) RecalculateAllMissingKeyspaces(w http.ResponseWriter,
 type CreateWorkflowRequest struct {
 	Name         string      `json:"name"`
 	PresetJobIDs []uuid.UUID `json:"preset_job_ids"`
+	// LoopbackAllEligible is the workflow-level master loopback toggle (GH #64).
+	LoopbackAllEligible bool `json:"loopback_all_eligible"`
+	// LoopbackPresetJobIDs are the preset jobs whose step has per-step loopback enabled.
+	// Ignored when LoopbackAllEligible is true.
+	LoopbackPresetJobIDs []uuid.UUID `json:"loopback_preset_job_ids"`
 }
 
 type UpdateWorkflowRequest struct {
-	Name         string      `json:"name"`
-	PresetJobIDs []uuid.UUID `json:"preset_job_ids"`
+	Name                 string      `json:"name"`
+	PresetJobIDs         []uuid.UUID `json:"preset_job_ids"`
+	LoopbackAllEligible  bool        `json:"loopback_all_eligible"`
+	LoopbackPresetJobIDs []uuid.UUID `json:"loopback_preset_job_ids"`
 }
 
 func (h *AdminJobsHandler) CreateJobWorkflow(w http.ResponseWriter, r *http.Request) {
@@ -423,7 +430,7 @@ func (h *AdminJobsHandler) CreateJobWorkflow(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	createdWorkflow, err := h.workflowService.CreateJobWorkflow(r.Context(), req.Name, req.PresetJobIDs)
+	createdWorkflow, err := h.workflowService.CreateJobWorkflow(r.Context(), req.Name, req.PresetJobIDs, req.LoopbackAllEligible, req.LoopbackPresetJobIDs)
 	if err != nil {
 		debug.Error("Error creating job workflow: %v", err)
 		httputil.RespondWithError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to create job workflow: %v", err))
@@ -448,7 +455,7 @@ func (h *AdminJobsHandler) ListJobWorkflows(w http.ResponseWriter, r *http.Reque
 		// Get workflow steps to check for high priority override
 		steps, err := h.workflowService.GetJobWorkflowByID(ctx, workflow.ID)
 		hasHighPriorityOverride := false
-		
+
 		if err == nil && steps != nil && steps.Steps != nil {
 			// Check each step's preset job for high priority override
 			for _, step := range steps.Steps {
@@ -463,20 +470,21 @@ func (h *AdminJobsHandler) ListJobWorkflows(w http.ResponseWriter, r *http.Reque
 				}
 			}
 		}
-		
+
 		enhancedWorkflow := map[string]interface{}{
-			"id":                        workflow.ID,
-			"name":                      workflow.Name,
-			"created_at":                workflow.CreatedAt,
-			"updated_at":                workflow.UpdatedAt,
+			"id":                         workflow.ID,
+			"name":                       workflow.Name,
+			"created_at":                 workflow.CreatedAt,
+			"updated_at":                 workflow.UpdatedAt,
 			"has_high_priority_override": hasHighPriorityOverride,
+			"loopback_all_eligible":      workflow.LoopbackAllEligible,
 		}
-		
+
 		// Include steps if they exist
 		if workflow.Steps != nil {
 			enhancedWorkflow["steps"] = workflow.Steps
 		}
-		
+
 		enhancedWorkflows = append(enhancedWorkflows, enhancedWorkflow)
 	}
 
@@ -529,7 +537,7 @@ func (h *AdminJobsHandler) UpdateJobWorkflow(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	updatedWorkflow, err := h.workflowService.UpdateJobWorkflow(r.Context(), id, req.Name, req.PresetJobIDs)
+	updatedWorkflow, err := h.workflowService.UpdateJobWorkflow(r.Context(), id, req.Name, req.PresetJobIDs, req.LoopbackAllEligible, req.LoopbackPresetJobIDs)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			httputil.RespondWithError(w, http.StatusNotFound, "Job workflow not found")

--- a/backend/internal/routes/filesync.go
+++ b/backend/internal/routes/filesync.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -131,13 +132,26 @@ func SetupFileDownloadRoutes(r *mux.Router, sqlDB *sql.DB, cfg *config.Config, a
 		}
 		defer file.Close()
 
+		// A mutable, append-only file (the global potfile) may be requested as its
+		// first N bytes via ?bytes=N so the delivered bytes match the md5 recorded
+		// over that same prefix [0,N). Absent/invalid → serve the whole file (for
+		// immutable files N == fileSize, so this is a harmless no-op).
+		serveSize := fileSize
+		if b := r.URL.Query().Get("bytes"); b != "" {
+			if n, perr := strconv.ParseInt(b, 10, 64); perr == nil && n >= 0 && n <= fileSize {
+				serveSize = n
+			} else {
+				debug.Warning("Ignoring invalid ?bytes=%q for %s (file size %d)", b, filename, fileSize)
+			}
+		}
+
 		// Set headers
 		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filepath.Base(filename)))
 		w.Header().Set("Content-Type", contentType)
-		w.Header().Set("Content-Length", fmt.Sprintf("%d", fileSize))
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", serveSize))
 
-		// Stream file to response
-		if _, err := io.Copy(w, file); err != nil {
+		// Stream file to response (bounded to serveSize)
+		if _, err := io.CopyN(w, file, serveSize); err != nil && err != io.EOF {
 			debug.Error("Failed to stream file: %v", err)
 			// Can't send error response here as headers are already sent
 		}
@@ -256,13 +270,26 @@ func SetupFileDownloadRoutes(r *mux.Router, sqlDB *sql.DB, cfg *config.Config, a
 		}
 		defer file.Close()
 
+		// A mutable, append-only file (the global potfile) may be requested as its
+		// first N bytes via ?bytes=N so the delivered bytes match the md5 recorded
+		// over that same prefix [0,N). Absent/invalid → serve the whole file (for
+		// immutable files N == fileSize, so this is a harmless no-op).
+		serveSize := fileSize
+		if b := r.URL.Query().Get("bytes"); b != "" {
+			if n, perr := strconv.ParseInt(b, 10, 64); perr == nil && n >= 0 && n <= fileSize {
+				serveSize = n
+			} else {
+				debug.Warning("Ignoring invalid ?bytes=%q for %s (file size %d)", b, filename, fileSize)
+			}
+		}
+
 		// Set headers
 		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filepath.Base(filename)))
 		w.Header().Set("Content-Type", contentType)
-		w.Header().Set("Content-Length", fmt.Sprintf("%d", fileSize))
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", serveSize))
 
-		// Stream file to response
-		if _, err := io.Copy(w, file); err != nil {
+		// Stream file to response (bounded to serveSize)
+		if _, err := io.CopyN(w, file, serveSize); err != nil && err != io.EOF {
 			debug.Error("Failed to stream file: %v", err)
 			// Can't send error response here as headers are already sent
 		}

--- a/backend/internal/routes/hashlist.go
+++ b/backend/internal/routes/hashlist.go
@@ -1448,6 +1448,18 @@ func (h *hashlistHandler) performPotfileRemoval(client *models.Client, globalRem
 			} else {
 				debug.Info("Removed %d plaintexts from global potfile after hashlist %d deletion",
 					removed, hashlistID)
+				// Refresh the global potfile's DB hash+size after the rewrite.
+				// RemovePlaintextsFromPotfile rewrites the file to a NEW inode
+				// (removing plaintexts + collapsing blank lines), which shifts the
+				// [0,N) prefix. Without this the DB metadata stays stale against the
+				// rewritten file, so agents fail MD5 verification (expected=old-prefix
+				// hash, got=new-inode prefix) until the next batch append happens to
+				// recompute it — a 10+ minute window under slow ingestion. Mirrors the
+				// client branch below (UpdateClientPotfileMetadata).
+				if err := h.potfileService.UpdatePotfileMetadata(context.Background()); err != nil {
+					debug.Error("Failed to update global potfile metadata after hashlist %d deletion: %v",
+						hashlistID, err)
+				}
 			}
 		}()
 	}

--- a/backend/internal/routes/user.go
+++ b/backend/internal/routes/user.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ZerkerEOD/krakenhashes/backend/internal/binary"
@@ -106,6 +107,14 @@ func CreateJobsHandler(database *db.DB, dataDir string, binaryManager binary.Man
 		dataDir,
 	)
 
+	// Create the loopback controller (GH #64) and start its monitor exactly once
+	// (CreateJobsHandler is invoked more than once during route setup).
+	loopbackRepo := repository.NewLoopbackRepository(dbWrapper)
+	loopbackService := services.NewLoopbackService(loopbackRepo, jobExecutionService, jobExecRepo, wordlistManager, systemSettingsRepo)
+	loopbackMonitorOnce.Do(func() {
+		go loopbackService.Start(context.Background())
+	})
+
 	// Create jobs handler
 	return jobs.NewUserJobsHandler(
 		jobExecRepo,
@@ -128,8 +137,12 @@ func CreateJobsHandler(database *db.DB, dataDir string, binaryManager binary.Man
 		teamService,
 		charsetRepo,
 		benchmarkRepo,
+		loopbackService,
 	)
 }
+
+// loopbackMonitorOnce guards the single loopback monitor goroutine.
+var loopbackMonitorOnce sync.Once
 
 // SetupUserRoutes configures all user-related routes
 func SetupUserRoutes(router *mux.Router, database *db.DB, dataDir string, binaryManager binary.Manager, agentService *services.AgentService, teamService *services.TeamService) {
@@ -152,6 +165,9 @@ func SetupUserRoutes(router *mux.Router, database *db.DB, dataDir string, binary
 
 	// User-specific jobs route
 	router.HandleFunc("/user/jobs", jobsHandler.ListUserJobs).Methods("GET", "OPTIONS")
+
+	// Loopback sessions ("Pending Loopback" list, GH #64)
+	router.HandleFunc("/loopback-sessions", jobsHandler.ListLoopbackSessions).Methods("GET", "OPTIONS")
 
 	// User-specific agents route with current task info
 	router.HandleFunc("/user/agents", agentHandler.GetUserAgents).Methods("GET", "OPTIONS")

--- a/backend/internal/services/admin_job_workflow_service.go
+++ b/backend/internal/services/admin_job_workflow_service.go
@@ -14,10 +14,10 @@ import (
 
 // AdminJobWorkflowService defines the interface for managing job workflows.
 type AdminJobWorkflowService interface {
-	CreateJobWorkflow(ctx context.Context, name string, presetJobIDs []uuid.UUID) (*models.JobWorkflow, error)
+	CreateJobWorkflow(ctx context.Context, name string, presetJobIDs []uuid.UUID, loopbackAllEligible bool, loopbackPresetJobIDs []uuid.UUID) (*models.JobWorkflow, error)
 	GetJobWorkflowByID(ctx context.Context, id uuid.UUID) (*models.JobWorkflow, error)
 	ListJobWorkflows(ctx context.Context) ([]models.JobWorkflow, error)
-	UpdateJobWorkflow(ctx context.Context, id uuid.UUID, name string, presetJobIDs []uuid.UUID) (*models.JobWorkflow, error)
+	UpdateJobWorkflow(ctx context.Context, id uuid.UUID, name string, presetJobIDs []uuid.UUID, loopbackAllEligible bool, loopbackPresetJobIDs []uuid.UUID) (*models.JobWorkflow, error)
 	DeleteJobWorkflow(ctx context.Context, id uuid.UUID) error
 	GetJobWorkflowFormData(ctx context.Context) ([]models.PresetJobBasic, error)
 }
@@ -36,6 +36,15 @@ func NewAdminJobWorkflowService(db *sql.DB, workflowRepo repository.JobWorkflowR
 		workflowRepo:  workflowRepo,
 		presetJobRepo: presetJobRepo, // Inject PresetJobRepository
 	}
+}
+
+// toUUIDSet builds a lookup set from a slice of UUIDs.
+func toUUIDSet(ids []uuid.UUID) map[uuid.UUID]bool {
+	set := make(map[uuid.UUID]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+	return set
 }
 
 // validateWorkflowInput performs input validation for create/update operations.
@@ -82,13 +91,14 @@ func (s *adminJobWorkflowService) validateWorkflowInput(ctx context.Context, nam
 }
 
 // CreateJobWorkflow creates a new workflow and its steps transactionally.
-func (s *adminJobWorkflowService) CreateJobWorkflow(ctx context.Context, name string, presetJobIDs []uuid.UUID) (*models.JobWorkflow, error) {
+func (s *adminJobWorkflowService) CreateJobWorkflow(ctx context.Context, name string, presetJobIDs []uuid.UUID, loopbackAllEligible bool, loopbackPresetJobIDs []uuid.UUID) (*models.JobWorkflow, error) {
 	if err := s.validateWorkflowInput(ctx, name, presetJobIDs, false, uuid.Nil); err != nil {
 		return nil, fmt.Errorf("validation failed: %w", err)
 	}
 
 	debug.Info("Attempting to create job workflow: %s", name)
 
+	loopbackSet := toUUIDSet(loopbackPresetJobIDs)
 	var createdWorkflow *models.JobWorkflow
 	createdSteps := make([]models.JobWorkflowStep, 0, len(presetJobIDs))
 
@@ -98,7 +108,7 @@ func (s *adminJobWorkflowService) CreateJobWorkflow(ctx context.Context, name st
 		// 1. Create the workflow record
 		// Assuming repo methods are modified to accept *sql.Tx (or we pass ctx and repo uses internal DB handle)
 		// For now, let's assume repo methods don't take Tx and work directly on s.db within the transaction context
-		createdWorkflow, err = s.workflowRepo.CreateWorkflow(ctx, name) // Need repo to work with Tx or handle context
+		createdWorkflow, err = s.workflowRepo.CreateWorkflow(ctx, name, loopbackAllEligible) // Need repo to work with Tx or handle context
 		if err != nil {
 			return fmt.Errorf("failed to create workflow record in transaction: %w", err)
 		}
@@ -106,7 +116,7 @@ func (s *adminJobWorkflowService) CreateJobWorkflow(ctx context.Context, name st
 		// 2. Create the steps
 		for i, presetID := range presetJobIDs {
 			stepOrder := i + 1 // Steps are 1-indexed
-			step, stepErr := s.workflowRepo.CreateWorkflowStep(ctx, createdWorkflow.ID, presetID, stepOrder)
+			step, stepErr := s.workflowRepo.CreateWorkflowStep(ctx, createdWorkflow.ID, presetID, stepOrder, loopbackSet[presetID])
 			if stepErr != nil {
 				return fmt.Errorf("failed to create workflow step %d in transaction: %w", stepOrder, stepErr)
 			}
@@ -159,7 +169,7 @@ func (s *adminJobWorkflowService) ListJobWorkflows(ctx context.Context) ([]model
 }
 
 // UpdateJobWorkflow updates a workflow name and replaces its steps transactionally.
-func (s *adminJobWorkflowService) UpdateJobWorkflow(ctx context.Context, id uuid.UUID, name string, presetJobIDs []uuid.UUID) (*models.JobWorkflow, error) {
+func (s *adminJobWorkflowService) UpdateJobWorkflow(ctx context.Context, id uuid.UUID, name string, presetJobIDs []uuid.UUID, loopbackAllEligible bool, loopbackPresetJobIDs []uuid.UUID) (*models.JobWorkflow, error) {
 	// 1. Check if workflow exists first
 	_, err := s.GetJobWorkflowByID(ctx, id)
 	if err != nil {
@@ -173,6 +183,7 @@ func (s *adminJobWorkflowService) UpdateJobWorkflow(ctx context.Context, id uuid
 
 	debug.Info("Attempting to update job workflow ID: %s", id)
 
+	loopbackSet := toUUIDSet(loopbackPresetJobIDs)
 	var updatedWorkflow *models.JobWorkflow
 	createdSteps := make([]models.JobWorkflowStep, 0, len(presetJobIDs))
 
@@ -180,7 +191,7 @@ func (s *adminJobWorkflowService) UpdateJobWorkflow(ctx context.Context, id uuid
 	err = s.executeTransaction(ctx, func(tx *sql.Tx) error {
 		var err error
 		// 3. Update workflow name
-		updatedWorkflow, err = s.workflowRepo.UpdateWorkflow(ctx, id, name)
+		updatedWorkflow, err = s.workflowRepo.UpdateWorkflow(ctx, id, name, loopbackAllEligible)
 		if err != nil {
 			return fmt.Errorf("failed to update workflow name in transaction: %w", err)
 		}
@@ -194,7 +205,7 @@ func (s *adminJobWorkflowService) UpdateJobWorkflow(ctx context.Context, id uuid
 		// 5. Create new steps
 		for i, presetID := range presetJobIDs {
 			stepOrder := i + 1
-			step, stepErr := s.workflowRepo.CreateWorkflowStep(ctx, id, presetID, stepOrder)
+			step, stepErr := s.workflowRepo.CreateWorkflowStep(ctx, id, presetID, stepOrder, loopbackSet[presetID])
 			if stepErr != nil {
 				return fmt.Errorf("failed to create workflow step %d in transaction: %w", stepOrder, stepErr)
 			}
@@ -287,6 +298,8 @@ func (s *adminJobWorkflowService) GetJobWorkflowFormData(ctx context.Context) ([
 			ID:                        job.ID,
 			Name:                      job.Name,
 			AllowHighPriorityOverride: job.AllowHighPriorityOverride,
+			AttackMode:                job.AttackMode,
+			RuleIDs:                   job.RuleIDs,
 		}
 	}
 

--- a/backend/internal/services/errorclass/classify.go
+++ b/backend/internal/services/errorclass/classify.go
@@ -93,6 +93,9 @@ var agentPersistentMarkers = []string{
 	"compatible platform found",
 	"self-test failed",
 	"selftest failed",
+	// Bare "autotune" wording from agents that don't emit the typed code stays
+	// persistent. The typed AGENT_AUTOTUNE code is intercepted earlier in
+	// Classify and treated as transient (the agent already retried with --force).
 	"autotune",
 }
 
@@ -127,6 +130,16 @@ func Classify(message string) Category {
 		return CategoryUnknown
 	}
 	m := strings.ToLower(message)
+	// Typed-code precedence: AGENT_AUTOTUNE reaches the backend only after the
+	// agent already retried the task locally with --force (which bypasses
+	// autotune) and it still failed. That's a per-job/per-agent quirk on this
+	// hardware, not a broken agent, so classify it transient (retry / fail over,
+	// never quarantine) — overriding the generic "autotune" persistent marker
+	// below. AGENT_NO_WORK (clean exit that processed nothing) is likewise a
+	// re-dispatch, not an agent fault.
+	if strings.Contains(m, "agent_autotune") || strings.Contains(m, "agent_no_work") {
+		return CategoryAgentTransient
+	}
 	if containsAny(m, hashlistFatalMarkers) {
 		return CategoryHashlistFatal
 	}

--- a/backend/internal/services/errorclass/classify_test.go
+++ b/backend/internal/services/errorclass/classify_test.go
@@ -21,6 +21,9 @@ func TestClassify(t *testing.T) {
 		{"no platform", "ATTENTION! No OpenCL, HIP or CUDA compatible platform found", CategoryAgentPersistent},
 		{"cuda init", "cuInit(): no CUDA-capable device is detected", CategoryAgentPersistent},
 		{"zero speed", "BENCHMARK_ZERO_SPEED: every device reported 0 H/s", CategoryAgentPersistent},
+		{"typed autotune retryable", "AGENT_AUTOTUNE: kernel autotune failure skipped the device before any candidates were tested (hashcat exit 0)", CategoryAgentTransient},
+		{"typed no work", "AGENT_NO_WORK: hashcat exited 0 without processing any candidates (no status ever reported)", CategoryAgentTransient},
+		{"bare autotune stays persistent", "Aborting session due to kernel autotune failures, for all active devices", CategoryAgentPersistent},
 		{"invalid mask", "Invalid mask '?z' in mask-file", CategoryJobConfig},
 		{"unknown", "something totally unexpected happened", CategoryUnknown},
 	}

--- a/backend/internal/services/job_progress_calculation_service.go
+++ b/backend/internal/services/job_progress_calculation_service.go
@@ -228,10 +228,16 @@ func (s *JobProgressCalculationService) calculateIncrementJobProgress(ctx contex
 	var totalProcessedKeyspace models.BigInt
 	var totalDispatchedKeyspace models.BigInt
 	var totalEffectiveKeyspace models.BigInt
+	var totalProcessedBaseKeyspace int64
+	var totalBaseKeyspace int64
 
 	for _, layer := range layers {
 		totalProcessedKeyspace = totalProcessedKeyspace.Add(layer.ProcessedKeyspace)
 		totalDispatchedKeyspace = totalDispatchedKeyspace.Add(layer.DispatchedKeyspace)
+		totalProcessedBaseKeyspace += layer.ProcessedBaseKeyspace
+		if layer.BaseKeyspace != nil {
+			totalBaseKeyspace += *layer.BaseKeyspace
+		}
 		if layer.EffectiveKeyspace != nil {
 			totalEffectiveKeyspace = totalEffectiveKeyspace.Add(*layer.EffectiveKeyspace)
 		} else if layer.BaseKeyspace != nil {
@@ -239,13 +245,49 @@ func (s *JobProgressCalculationService) calculateIncrementJobProgress(ctx contex
 		}
 	}
 
-	// Calculate overall progress percentage
+	// Self-heal: while the job is ACTIVE, keep the JOB row's base/effective keyspace
+	// equal to the sum of its layers. For increment jobs the layers are the source of
+	// truth; the job-level values are a derived aggregate the frontend keyspace bar
+	// uses as its denominator. Other writers can clobber these single columns with
+	// single-mask values without touching the layers (e.g. HandleWordlistUpdate on a
+	// growing potfile, or a job-targeted benchmark) — recompute them from Σ layer every
+	// cycle so the bar and progress % stay consistent. Conditional writes avoid churn.
+	//
+	// Skip once completed: CompleteJobExecution owns the terminal effective_keyspace
+	// (it syncs effective DOWN to processed on an all-cracked early completion so the
+	// job reads 100%). Re-asserting Σ layer here in the 15s post-completion poll window
+	// would fight that and make a done job read <100%.
+	if job.Status != models.JobExecutionStatusCompleted {
+		if totalBaseKeyspace > 0 && (job.BaseKeyspace == nil || *job.BaseKeyspace != totalBaseKeyspace) {
+			if err := s.jobExecRepo.UpdateBaseKeyspace(ctx, job.ID, totalBaseKeyspace); err != nil {
+				debug.Warning("Failed to sync increment job %s base_keyspace to layer sum %d: %v", job.ID, totalBaseKeyspace, err)
+			}
+		}
+		if totalEffectiveKeyspace.IsPositive() && (job.EffectiveKeyspace == nil || job.EffectiveKeyspace.Cmp(totalEffectiveKeyspace) != 0) {
+			if err := s.jobExecRepo.UpdateEffectiveKeyspace(ctx, job.ID, totalEffectiveKeyspace); err != nil {
+				debug.Warning("Failed to sync increment job %s effective_keyspace to layer sum %s: %v", job.ID, totalEffectiveKeyspace.String(), err)
+			}
+		}
+	}
+
+	// Overall progress percentage — base-driven, matching calculateRegularJobProgress.
+	// Base keyspace is the invariant coverage dimension (Σ layer base_keyspace ==
+	// job.BaseKeyspace) and is structurally <= 100%, so the increment display no longer
+	// drifts past 100% when hashcat's real effective candidate count exceeds the
+	// init-time --total-candidates / mask-math estimate. The effective sums are kept
+	// only for the processed/dispatched candidate-count display.
 	progressPercent := 0.0
-	if totalEffectiveKeyspace.IsPositive() {
+	if totalBaseKeyspace > 0 {
+		progressPercent = float64(totalProcessedBaseKeyspace) / float64(totalBaseKeyspace) * 100
+		if progressPercent > 100 {
+			// Transient in-flight restore_point overshoot; clamp quietly (base
+			// coverage can't genuinely exceed the summed layer keyspace).
+			progressPercent = 100
+		}
+	} else if totalEffectiveKeyspace.IsPositive() {
+		// No base keyspace (should not happen post-init) — fall back to effective.
 		progressPercent = float64(totalProcessedKeyspace.Int64()) / float64(totalEffectiveKeyspace.Int64()) * 100
 		if progressPercent > 100 {
-			debug.Warning("Job %s progress exceeds 100%% (%.3f%%), capping at 100%%. Processed: %s, Effective: %s",
-				job.ID, progressPercent, totalProcessedKeyspace.String(), totalEffectiveKeyspace.String())
 			progressPercent = 100
 		}
 	}
@@ -278,6 +320,13 @@ func (s *JobProgressCalculationService) calculateRegularJobProgress(ctx context.
 
 		var lastEnd int64 = 0
 		for _, task := range sortedTasks {
+			// Failed/cancelled tasks have their keyspace interval reopened as a gap
+			// and re-dispatched, so a stale [start,end) row must NOT count as an
+			// overlap against the fresh task covering the same range. Skip them,
+			// matching the coverage math below which also excludes these.
+			if task.Status == models.JobTaskStatusFailed || task.Status == models.JobTaskStatusCancelled {
+				continue
+			}
 			if task.KeyspaceStart < lastEnd && task.KeyspaceEnd > 0 {
 				debug.Error("OVERLAP DETECTED in job %s: task %s starts at %d but previous task ended at %d (overlap: %d)",
 					job.ID, task.ID, task.KeyspaceStart, lastEnd, lastEnd-task.KeyspaceStart)
@@ -451,6 +500,11 @@ func (s *JobProgressCalculationService) calculateAndUpdateLayerProgress(ctx cont
 
 		var lastEnd int64 = 0
 		for _, task := range layerTasks {
+			// Skip failed/cancelled tasks: their interval is reopened and
+			// re-dispatched, so a stale row must not trip a false overlap.
+			if task.Status == models.JobTaskStatusFailed || task.Status == models.JobTaskStatusCancelled {
+				continue
+			}
 			if task.KeyspaceStart < lastEnd && task.KeyspaceEnd > 0 {
 				debug.Error("OVERLAP DETECTED in layer %s (job %s): task %s starts at %d but previous task ended at %d (overlap: %d)",
 					layer.ID, layer.JobExecutionID, task.ID, task.KeyspaceStart, lastEnd, lastEnd-task.KeyspaceStart)
@@ -487,8 +541,35 @@ func (s *JobProgressCalculationService) calculateAndUpdateLayerProgress(ctx cont
 	// 3) Fall back to raw KeyspaceProcessed for non-split layers
 	var processedKeyspace models.BigInt
 	var dispatchedKeyspace models.BigInt
+	var processedBaseKeyspace int64
 	for _, task := range layerTasks {
 		chunkSize := task.KeyspaceEnd - task.KeyspaceStart
+
+		// BASE-unit progress for this layer (drift-free percentage numerator).
+		// Mirrors calculateRegularJobProgress: completed tasks count their full
+		// chunk; active tasks count their clamped restore_point; failed/cancelled
+		// ranges (reopened as gaps) count for nothing.
+		if task.Status != models.JobTaskStatusFailed && task.Status != models.JobTaskStatusCancelled {
+			if task.Status == models.JobTaskStatusCompleted {
+				if chunkSize > 0 {
+					processedBaseKeyspace += chunkSize
+				}
+			} else {
+				var baseProc int64
+				if task.KeyspaceStart > 0 && task.KeyspaceProcessed >= task.KeyspaceStart {
+					baseProc = task.KeyspaceProcessed - task.KeyspaceStart
+				} else {
+					baseProc = task.KeyspaceProcessed
+				}
+				if baseProc < 0 {
+					baseProc = 0
+				}
+				if chunkSize > 0 && baseProc > chunkSize {
+					baseProc = chunkSize
+				}
+				processedBaseKeyspace += baseProc
+			}
+		}
 
 		if task.EffectiveKeyspaceProcessed != nil && task.EffectiveKeyspaceProcessed.IsPositive() {
 			// Preferred path — agent reported effective progress (unambiguous candidate count).
@@ -521,15 +602,22 @@ func (s *JobProgressCalculationService) calculateAndUpdateLayerProgress(ctx cont
 		}
 	}
 
-	// Calculate layer progress percentage
+	// Calculate layer progress percentage.
+	// Base-driven (matches calculateRegularJobProgress): both numerator and
+	// denominator are BASE units — the invariant chunkable dimension (hashcat
+	// --skip/--limit) — so the value is immune to effective-keyspace estimate
+	// drift and structurally <= 100%. Effective keyspace is retained only for the
+	// candidate-count display (processed_keyspace), never as the % denominator.
 	progressPercent := 0.0
-	if layer.EffectiveKeyspace != nil && layer.EffectiveKeyspace.IsPositive() {
-		progressPercent = float64(processedKeyspace.Int64()) / float64(layer.EffectiveKeyspace.Int64()) * 100
+	if layer.BaseKeyspace != nil && *layer.BaseKeyspace > 0 {
+		progressPercent = float64(processedBaseKeyspace) / float64(*layer.BaseKeyspace) * 100
 		if progressPercent > 100 {
+			// Transient in-flight restore_point overshoot; clamp quietly.
 			progressPercent = 100
 		}
-	} else if layer.BaseKeyspace != nil && *layer.BaseKeyspace > 0 {
-		progressPercent = float64(processedKeyspace.Int64()) / float64(*layer.BaseKeyspace) * 100
+	} else if layer.EffectiveKeyspace != nil && layer.EffectiveKeyspace.IsPositive() {
+		// No base keyspace (should not happen post-init) — fall back to effective.
+		progressPercent = float64(processedKeyspace.Int64()) / float64(layer.EffectiveKeyspace.Int64()) * 100
 		if progressPercent > 100 {
 			progressPercent = 100
 		}
@@ -548,6 +636,29 @@ func (s *JobProgressCalculationService) calculateAndUpdateLayerProgress(ctx cont
 	layer.ProcessedKeyspace = processedKeyspace
 	layer.DispatchedKeyspace = dispatchedKeyspace
 	layer.OverallProgressPercent = progressPercent
+	// ProcessedBaseKeyspace feeds the base-driven job-level percentage (in-memory only).
+	layer.ProcessedBaseKeyspace = processedBaseKeyspace
+
+	// Reconcile the layer's stored effective keyspace UP toward the REAL value hashcat
+	// reported. Mirrors the job-level self-heal (job_execution_service completion sync
+	// and the completion feedback loop, which sync effective UP to processed): when
+	// actual processed exceeds the init-time estimate (--total-candidates / mask-math),
+	// the estimate was low, so raise effective to the real candidate count. This keeps
+	// Σ layer.effective_keyspace equal to the job's effective (which the completion sync
+	// pins to actual processed) so the frontend keyspace bar tiles [0, job.effective)
+	// with no trailing non-green gap. Grows only, never shrinks (mid-run progress never
+	// jumps), and writes only when the value actually changes.
+	if processedKeyspace.IsPositive() &&
+		(layer.EffectiveKeyspace == nil || processedKeyspace.Cmp(*layer.EffectiveKeyspace) > 0) {
+		reconciled := models.BigIntPtrFromBig(processedKeyspace.Big())
+		if err := s.jobIncrementLayerRepo.UpdateEffectiveKeyspace(ctx, layer.ID, *reconciled); err != nil {
+			debug.Warning("Failed to reconcile layer %s effective keyspace to actual (%s): %v",
+				layer.ID, processedKeyspace.String(), err)
+		} else {
+			layer.EffectiveKeyspace = reconciled
+			layer.IsAccurateKeyspace = true
+		}
+	}
 
 	return nil
 }

--- a/backend/internal/services/job_update_service.go
+++ b/backend/internal/services/job_update_service.go
@@ -88,6 +88,18 @@ func (s *JobUpdateService) HandleWordlistUpdate(ctx context.Context, wordlistID 
 		s.lockJob(job.ID.String())
 		defer s.unlockJob(job.ID.String())
 
+		// Increment-mode jobs track keyspace PER LAYER; the job-level
+		// base_keyspace/effective_keyspace are a derived sum maintained by the
+		// progress calculator (calculateIncrementJobProgress). Rewriting them here
+		// with a single wordlist line-count would clobber the layer sums with a
+		// single-mask value and never touch the layers — exactly the drift that
+		// made an increment job's effective_keyspace (denominator) diverge from
+		// Σ layer effective. Leave increment jobs to their per-layer accounting.
+		if job.IncrementMode != "" && job.IncrementMode != "off" {
+			debug.Info("Wordlist update: job %s is increment-mode; keyspace is tracked per layer — skipping job-level keyspace rewrite", job.ID)
+			continue
+		}
+
 		// Forward-only guard: if every word of the CURRENT base keyspace has
 		// already been dispatched (max(keyspace_end) across non-failed tasks >=
 		// base_keyspace), the job has no undispatched work left. Appending to the

--- a/backend/internal/services/loopback_service.go
+++ b/backend/internal/services/loopback_service.go
@@ -1,0 +1,344 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/ZerkerEOD/krakenhashes/backend/internal/models"
+	"github.com/ZerkerEOD/krakenhashes/backend/internal/repository"
+	"github.com/ZerkerEOD/krakenhashes/backend/internal/wordlist"
+	"github.com/ZerkerEOD/krakenhashes/backend/pkg/debug"
+	"github.com/google/uuid"
+)
+
+// loopbackMonitorInterval is how often the controller re-evaluates in-flight loopback
+// sessions. It is idle-gated (see LoopbackRepository.HasActiveSessions), so a tick with
+// no active session is a single cheap EXISTS query.
+const loopbackMonitorInterval = 7 * time.Second
+
+// defaultLoopbackMaxRounds bounds how many delta rounds a session runs if the
+// loopback_max_rounds system setting is missing.
+const defaultLoopbackMaxRounds = 10
+
+// LoopbackOrigin describes a round-0 job that belongs to a new loopback session.
+type LoopbackOrigin struct {
+	JobExecutionID uuid.UUID
+	IsMutatable    bool
+}
+
+// LoopbackService is the durable controller for the loopback feature (GH #64). It
+// monitors each session's current round, and once that round's jobs finish it computes
+// the delta of newly-cracked plaintexts and spawns re-runs of the mutatable jobs against
+// it — repeating until a round produces nothing new (or the max-rounds cap is hit).
+type LoopbackService struct {
+	repo               *repository.LoopbackRepository
+	jobExecService     *JobExecutionService
+	jobExecRepo        *repository.JobExecutionRepository
+	wordlistManager    wordlist.Manager
+	systemSettingsRepo *repository.SystemSettingsRepository
+}
+
+// NewLoopbackService creates the loopback controller.
+func NewLoopbackService(
+	repo *repository.LoopbackRepository,
+	jobExecService *JobExecutionService,
+	jobExecRepo *repository.JobExecutionRepository,
+	wordlistManager wordlist.Manager,
+	systemSettingsRepo *repository.SystemSettingsRepository,
+) *LoopbackService {
+	return &LoopbackService{
+		repo:               repo,
+		jobExecService:     jobExecService,
+		jobExecRepo:        jobExecRepo,
+		wordlistManager:    wordlistManager,
+		systemSettingsRepo: systemSettingsRepo,
+	}
+}
+
+// CreateSession records a new loopback session and its round-0 jobs. Called from the
+// create-job flow once the original jobs have been created. Origins with IsMutatable
+// true are the lineages that will be re-run against the delta each round.
+func (s *LoopbackService) CreateSession(ctx context.Context, hashlistID int64, sourceType models.LoopbackSourceType, sourceWorkflowID *uuid.UUID, name string, createdBy *uuid.UUID, origins []LoopbackOrigin) (*models.LoopbackSession, error) {
+	if len(origins) == 0 {
+		return nil, fmt.Errorf("cannot create a loopback session with no jobs")
+	}
+
+	session := &models.LoopbackSession{
+		HashlistID:       hashlistID,
+		SourceType:       sourceType,
+		SourceWorkflowID: sourceWorkflowID,
+		Name:             name,
+		Status:           models.LoopbackSessionStatusWaiting,
+		CurrentRound:     0,
+		MaxRounds:        s.resolveMaxRounds(ctx),
+		CreatedBy:        createdBy,
+	}
+
+	jobs := make([]models.LoopbackSessionJob, 0, len(origins))
+	for _, o := range origins {
+		jobs = append(jobs, models.LoopbackSessionJob{
+			JobExecutionID: o.JobExecutionID,
+			Round:          0,
+			Role:           models.LoopbackJobRoleOriginal,
+			IsMutatable:    o.IsMutatable,
+		})
+	}
+
+	if err := s.repo.CreateSessionWithJobs(ctx, session, jobs); err != nil {
+		return nil, err
+	}
+
+	debug.Info("Created loopback session %s (%s) for hashlist %d with %d round-0 jobs", session.ID, sourceType, hashlistID, len(origins))
+	return session, nil
+}
+
+// ListSessions returns loopback sessions (with their jobs populated) for the UI. Pass a
+// non-nil createdBy to scope to one user, or nil for all (admins).
+func (s *LoopbackService) ListSessions(ctx context.Context, createdBy *uuid.UUID) ([]*models.LoopbackSession, error) {
+	sessions, err := s.repo.ListSessions(ctx, createdBy, 100)
+	if err != nil {
+		return nil, err
+	}
+	for _, sess := range sessions {
+		jobs, jerr := s.repo.GetSessionJobs(ctx, sess.ID)
+		if jerr != nil {
+			debug.Warning("Failed to load jobs for loopback session %s: %v", sess.ID, jerr)
+			continue
+		}
+		sess.Jobs = jobs
+	}
+	return sessions, nil
+}
+
+// resolveMaxRounds reads the loopback_max_rounds system setting (falling back to the
+// default). It caps how many delta rounds any session runs.
+func (s *LoopbackService) resolveMaxRounds(ctx context.Context) int {
+	if s.systemSettingsRepo == nil {
+		return defaultLoopbackMaxRounds
+	}
+	setting, err := s.systemSettingsRepo.GetSetting(ctx, "loopback_max_rounds")
+	if err == nil && setting != nil && setting.Value != nil {
+		if parsed, perr := parseIntValueFromString(*setting.Value); perr == nil && parsed > 0 {
+			return parsed
+		}
+	}
+	return defaultLoopbackMaxRounds
+}
+
+// Start runs the monitor loop until the context is cancelled. Because it re-queries
+// waiting/active sessions each tick, a backend restart is transparently recovered: the
+// first tick after boot re-evaluates every unfinished session.
+func (s *LoopbackService) Start(ctx context.Context) {
+	debug.Info("Loopback monitor started (interval %s)", loopbackMonitorInterval)
+	ticker := time.NewTicker(loopbackMonitorInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			debug.Info("Loopback monitor stopping")
+			return
+		case <-ticker.C:
+			s.tick(ctx)
+		}
+	}
+}
+
+// tick processes all in-flight sessions. It is idle-gated so a system with no loopback
+// work does a single EXISTS query per interval.
+func (s *LoopbackService) tick(ctx context.Context) {
+	active, err := s.repo.HasActiveSessions(ctx)
+	if err != nil {
+		debug.Error("Loopback monitor: failed to check for active sessions: %v", err)
+		return
+	}
+	if !active {
+		return
+	}
+
+	sessions, err := s.repo.GetActiveSessions(ctx)
+	if err != nil {
+		debug.Error("Loopback monitor: failed to list active sessions: %v", err)
+		return
+	}
+	for _, session := range sessions {
+		if err := s.processSession(ctx, session); err != nil {
+			debug.Error("Loopback monitor: error processing session %s: %v", session.ID, err)
+		}
+	}
+}
+
+// processSession advances one session: if its current round is finished, it either
+// spawns the next delta round or completes the session.
+func (s *LoopbackService) processSession(ctx context.Context, session *models.LoopbackSession) error {
+	// Wait until every job of the current round has reached a terminal state.
+	nonTerminal, err := s.repo.CountNonTerminalRoundJobs(ctx, session.ID, session.CurrentRound)
+	if err != nil {
+		return err
+	}
+	if nonTerminal > 0 {
+		return nil // still running; re-check next tick
+	}
+
+	// A round-0 with no jobs (e.g. a workflow whose steps were all ineligible or failed
+	// to create) has nothing to loop back.
+	if session.CurrentRound == 0 {
+		count, err := s.repo.CountRoundJobs(ctx, session.ID, 0)
+		if err != nil {
+			return err
+		}
+		if count == 0 {
+			return s.complete(ctx, session, "no round-0 jobs to monitor")
+		}
+	}
+
+	// If there are no mutatable lineages, the loopback can never produce a re-run.
+	origins, err := s.repo.GetMutatableOriginJobs(ctx, session.ID)
+	if err != nil {
+		return err
+	}
+	if len(origins) == 0 {
+		return s.complete(ctx, session, "no mutatable jobs in this session")
+	}
+
+	// If the hashlist is fully cracked, there is nothing left for another round to find —
+	// stop now instead of spawning a wasted round against an exhausted hashlist.
+	hasUncracked, err := s.repo.HashlistHasUncracked(ctx, session.HashlistID)
+	if err != nil {
+		return err
+	}
+	if !hasUncracked {
+		return s.complete(ctx, session, "hashlist fully cracked")
+	}
+
+	// Honour the safety cap.
+	if session.CurrentRound >= session.MaxRounds {
+		debug.Info("Loopback session %s reached max rounds (%d); completing", session.ID, session.MaxRounds)
+		return s.complete(ctx, session, "")
+	}
+
+	// Compute the delta of never-before-used newly-cracked plaintexts.
+	delta, err := s.repo.GetNewDeltaPlaintexts(ctx, session.ID, session.HashlistID)
+	if err != nil {
+		return err
+	}
+	if len(delta) == 0 {
+		debug.Info("Loopback session %s is dry (no new plaintexts after round %d); completing", session.ID, session.CurrentRound)
+		return s.complete(ctx, session, "")
+	}
+
+	// Spawn a re-run for each mutatable lineage against the delta.
+	nextRound := session.CurrentRound + 1
+	spawned := 0
+	for _, origin := range origins {
+		originJob, err := s.jobExecRepo.GetByID(ctx, origin.JobExecutionID)
+		if err != nil {
+			debug.Error("Loopback session %s: failed to load origin job %s: %v", session.ID, origin.JobExecutionID, err)
+			continue
+		}
+		rerun, err := s.spawnRerun(ctx, session, originJob, delta, nextRound)
+		if err != nil {
+			debug.Error("Loopback session %s: failed to spawn re-run for origin %s: %v", session.ID, origin.JobExecutionID, err)
+			continue
+		}
+		originID := origin.JobExecutionID
+		if addErr := s.repo.AddSessionJob(ctx, &models.LoopbackSessionJob{
+			SessionID:      session.ID,
+			JobExecutionID: rerun.ID,
+			Round:          nextRound,
+			Role:           models.LoopbackJobRoleRerun,
+			IsMutatable:    true,
+			OriginJobID:    &originID,
+		}); addErr != nil {
+			debug.Error("Loopback session %s: failed to record re-run %s: %v", session.ID, rerun.ID, addErr)
+		}
+		spawned++
+	}
+
+	if spawned == 0 {
+		msg := "failed to spawn any loopback re-runs"
+		debug.Error("Loopback session %s: %s", session.ID, msg)
+		return s.repo.UpdateSessionStatus(ctx, session.ID, models.LoopbackSessionStatusFailed, session.CurrentRound, &msg)
+	}
+
+	// Mark this delta consumed so it is never re-run, and advance the round.
+	if err := s.repo.MarkPlaintextsUsed(ctx, session.ID, delta); err != nil {
+		debug.Error("Loopback session %s: failed to mark %d plaintexts used: %v", session.ID, len(delta), err)
+	}
+	debug.Info("Loopback session %s: spawned round %d with %d re-run(s) against %d new plaintext(s)", session.ID, nextRound, spawned, len(delta))
+	return s.repo.UpdateSessionStatus(ctx, session.ID, models.LoopbackSessionStatusActive, nextRound, nil)
+}
+
+// spawnRerun creates one loopback re-run: a job with the origin's mutation config
+// (rules/mask/mode/…) but its wordlist swapped for a freshly-materialized ephemeral
+// wordlist of the delta. It reuses the preparing→finalize flow so the ephemeral wordlist
+// is owned by (and cleaned up with) the new job, and keyspace is computed on the real
+// file before the job becomes schedulable.
+func (s *LoopbackService) spawnRerun(ctx context.Context, session *models.LoopbackSession, originJob *models.JobExecution, delta []string, round int) (*models.JobExecution, error) {
+	creator := session.CreatedBy
+	if creator == nil {
+		creator = originJob.CreatedBy
+	}
+	if creator == nil {
+		return nil, fmt.Errorf("cannot spawn loopback re-run: no creator to own the ephemeral wordlist")
+	}
+
+	name := fmt.Sprintf("%s (loopback R%d)", originJob.Name, round)
+	config := loopbackConfigFromJob(originJob, name)
+
+	// 1. Create the placeholder job (owns the ephemeral wordlist, ignored by scheduler).
+	prep, err := s.jobExecService.CreatePreparingFilterJob(ctx, config, session.HashlistID, creator, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create preparing loopback job: %w", err)
+	}
+
+	// 2. Materialize the delta into an ephemeral wordlist owned by that job.
+	wlName := fmt.Sprintf("loopback_%s_r%d", prep.ID.String()[:8], round)
+	wl, err := s.wordlistManager.MaterializeEphemeralWordlist(ctx, delta, wlName, prep.ID, *creator)
+	if err != nil {
+		_ = s.jobExecService.FailJob(ctx, prep.ID, fmt.Sprintf("loopback: failed to materialize delta wordlist: %v", err))
+		return nil, err
+	}
+
+	// 3. Swap the wordlist to the delta, compute keyspace, and open the dispatch gate.
+	config.WordlistIDs = models.IDArray{strconv.Itoa(wl.ID)}
+	if err := s.jobExecService.FinalizeFilterJob(ctx, prep.ID, config); err != nil {
+		_ = s.jobExecService.FailJob(ctx, prep.ID, fmt.Sprintf("loopback: failed to finalize job: %v", err))
+		return nil, err
+	}
+	return prep, nil
+}
+
+// complete marks a session completed (optionally with an informational reason).
+func (s *LoopbackService) complete(ctx context.Context, session *models.LoopbackSession, reason string) error {
+	if reason != "" {
+		debug.Info("Loopback session %s completed: %s", session.ID, reason)
+	}
+	return s.repo.UpdateSessionStatus(ctx, session.ID, models.LoopbackSessionStatusCompleted, session.CurrentRound, nil)
+}
+
+// loopbackConfigFromJob builds a custom-job config from an existing job_execution,
+// carrying over the mutation (rules/mask/mode/charsets/…) but leaving the wordlist for
+// the caller to fill with the delta.
+func loopbackConfigFromJob(job *models.JobExecution, name string) CustomJobConfig {
+	return CustomJobConfig{
+		Name:                      name,
+		WordlistIDs:               models.IDArray{}, // filled with the delta wordlist by the caller
+		RuleIDs:                   job.RuleIDs,
+		AttackMode:                job.AttackMode,
+		Mask:                      job.Mask,
+		CustomCharsets:            job.CustomCharsets,
+		CustomCharsetFiles:        job.CustomCharsetFiles,
+		HexCharset:                job.HexCharset,
+		Priority:                  job.Priority,
+		MaxAgents:                 job.MaxAgents,
+		BinaryVersion:             job.BinaryVersion,
+		AllowHighPriorityOverride: job.AllowHighPriorityOverride,
+		ChunkSizeSeconds:          job.ChunkSizeSeconds,
+		IncrementMode:             job.IncrementMode,
+		IncrementMin:              job.IncrementMin,
+		IncrementMax:              job.IncrementMax,
+		AdditionalArgs:            job.AdditionalArgs,
+	}
+}

--- a/backend/internal/services/potfile_service.go
+++ b/backend/internal/services/potfile_service.go
@@ -727,20 +727,33 @@ func (s *PotfileService) deleteProcessedEntriesInternal(ctx context.Context, ids
 	return nil
 }
 
-// calculatePotfileMD5 calculates the MD5 hash of the potfile
-func (s *PotfileService) calculatePotfileMD5() (string, error) {
+// calculatePotfileMD5 hashes the potfile over a fixed prefix [0, N) and returns
+// that hash together with N. The potfile is continuously appended, so the size is
+// captured FIRST and exactly that many bytes are hashed — the returned (hash,
+// size) therefore always describe the identical prefix. Callers store both so the
+// agent can verify a bounded [0,N) download (via ?bytes=N) instead of chasing the
+// ever-growing tail, which is what caused the permanent MD5-mismatch sync loop.
+func (s *PotfileService) calculatePotfileMD5() (string, int64, error) {
 	file, err := os.Open(s.potfilePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to open potfile for MD5 calculation: %w", err)
+		return "", 0, fmt.Errorf("failed to open potfile for MD5 calculation: %w", err)
 	}
 	defer file.Close()
-	
-	hash := md5.New()
-	if _, err := io.Copy(hash, file); err != nil {
-		return "", fmt.Errorf("failed to calculate MD5: %w", err)
+
+	// Capture the size first, then hash exactly that many bytes so an append
+	// landing mid-hash can't make the hash and size describe different prefixes.
+	info, err := file.Stat()
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to stat potfile for MD5 calculation: %w", err)
 	}
-	
-	return hex.EncodeToString(hash.Sum(nil)), nil
+	size := info.Size()
+
+	hash := md5.New()
+	if _, err := io.CopyN(hash, file, size); err != nil && err != io.EOF {
+		return "", 0, fmt.Errorf("failed to calculate MD5: %w", err)
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), size, nil
 }
 
 // getOrCreatePotfileWordlist gets or creates the pot-file wordlist entry
@@ -753,20 +766,15 @@ func (s *PotfileService) getOrCreatePotfileWordlist(ctx context.Context) (int, e
 	if err == nil {
 		debug.Info("Found existing pot-file wordlist with ID: %d", wordlistID)
 		
-		// Update the MD5 hash and file size for the existing wordlist
-		md5Hash, err := s.calculatePotfileMD5()
+		// Update the MD5 hash and file size for the existing wordlist. Hash and size
+		// describe the same prefix (see calculatePotfileMD5).
+		md5Hash, fileSize, err := s.calculatePotfileMD5()
 		if err != nil {
 			debug.Warning("Failed to calculate potfile MD5 for update: %v", err)
 			md5Hash = "68b329da9893e34099c7d8ad5cb9c940" // MD5 of "\n"
+			fileSize = 0
 		}
-		
-		// Get file size
-		fileInfo, err := os.Stat(s.potfilePath)
-		fileSize := int64(0)
-		if err == nil {
-			fileSize = fileInfo.Size()
-		}
-		
+
 		// Update the wordlist with correct MD5 and file size
 		debug.Info("Updating existing pot-file wordlist MD5: %s, size: %d", md5Hash, fileSize)
 		if err := s.wordlistStore.UpdateWordlistFileInfo(ctx, wordlistID, md5Hash, fileSize); err != nil {
@@ -787,21 +795,15 @@ func (s *PotfileService) getOrCreatePotfileWordlist(ctx context.Context) (int, e
 		return 0, fmt.Errorf("failed to get system user ID: %w", err)
 	}
 
-	// Calculate the actual MD5 hash of the potfile
-	md5Hash, err := s.calculatePotfileMD5()
+	// Calculate the actual MD5 hash of the potfile (hash + matching prefix size)
+	md5Hash, fileSize, err := s.calculatePotfileMD5()
 	if err != nil {
 		// If we can't calculate MD5 (file might not exist yet), use a fallback
 		debug.Warning("Failed to calculate potfile MD5, using default: %v", err)
 		md5Hash = "68b329da9893e34099c7d8ad5cb9c940" // MD5 of "\n"
+		fileSize = 0
 	}
-	
-	// Get file size
-	fileInfo, err := os.Stat(s.potfilePath)
-	fileSize := int64(0)
-	if err == nil {
-		fileSize = fileInfo.Size()
-	}
-	
+
 	// Create new wordlist entry
 	wordlist := &models.Wordlist{
 		Name:               "Pot-file",
@@ -1091,19 +1093,15 @@ func (s *PotfileService) monitorForBinaryAndCreatePresetJob(ctx context.Context,
 
 // UpdatePotfileMetadata updates the MD5 hash and file size of the potfile in the database
 func (s *PotfileService) UpdatePotfileMetadata(ctx context.Context) error {
-	// Calculate the current MD5 hash of the potfile
-	md5Hash, err := s.calculatePotfileMD5()
+	// Calculate the current MD5 hash of the potfile AND the size of the exact
+	// prefix it covers. Do not re-stat for size — an append landing between the
+	// hash and a separate stat would make the stored size describe a larger range
+	// than the hash, which is what broke agent verification.
+	md5Hash, fileSize, err := s.calculatePotfileMD5()
 	if err != nil {
 		return fmt.Errorf("failed to calculate potfile MD5: %w", err)
 	}
-	
-	// Get the current file size
-	fileInfo, err := os.Stat(s.potfilePath)
-	if err != nil {
-		return fmt.Errorf("failed to get potfile info: %w", err)
-	}
-	fileSize := fileInfo.Size()
-	
+
 	// Count the actual lines in the potfile
 	lineCount, err := s.countPotfileLines()
 	if err != nil {

--- a/backend/internal/wordlist/manager.go
+++ b/backend/internal/wordlist/manager.go
@@ -61,6 +61,9 @@ type Manager interface {
 	GetFilteredChildren(ctx context.Context, parentID int) ([]*models.Wordlist, error)
 	GetEphemeralWordlistsByJob(ctx context.Context, jobID uuid.UUID) ([]*models.Wordlist, error)
 	SetWordlistOwnerJob(ctx context.Context, wordlistID int, jobID uuid.UUID) error
+
+	// Loopback (GH #64)
+	MaterializeEphemeralWordlist(ctx context.Context, words []string, name string, ownerJobID uuid.UUID, userID uuid.UUID) (*models.Wordlist, error)
 }
 
 // Store defines the interface for wordlist data storage operations
@@ -1217,6 +1220,109 @@ func (m *manager) CreateFilteredWordlistRecord(ctx context.Context, parentID int
 // (used for cleanup once the job ends).
 func (m *manager) SetWordlistOwnerJob(ctx context.Context, wordlistID int, jobID uuid.UUID) error {
 	return m.store.SetWordlistOwnerJob(ctx, wordlistID, jobID)
+}
+
+// MaterializeEphemeralWordlist writes an in-memory set of words to a new ephemeral
+// wordlist file and registers it verified with its final word count (GH #64 loopback).
+// Unlike CreateFilteredWordlistRecord it has no parent and no filter — the words are
+// provided directly (a loopback delta of freshly-cracked plaintexts). The wordlist is
+// job-scoped (is_ephemeral + owner_job_id) so it inherits the ephemeral cleanup and the
+// DirectoryMonitor __eph__ skip. The file is staged to a hidden dotfile and atomically
+// renamed into place, mirroring FilterWordlist.
+func (m *manager) MaterializeEphemeralWordlist(ctx context.Context, words []string, name string, ownerJobID uuid.UUID, userID uuid.UUID) (*models.Wordlist, error) {
+	if len(words) == 0 {
+		return nil, fmt.Errorf("cannot materialize an empty wordlist")
+	}
+
+	base := fsutil.SanitizeFilename(name)
+	if base == "" {
+		base = "loopback"
+	}
+	fileName := filepath.Join("custom", fmt.Sprintf("%s%s_%s.txt", EphemeralFilenamePrefix, base, uuid.New().String()[:8]))
+	dstPath := m.GetWordlistPath(fileName, "custom")
+
+	if err := os.MkdirAll(filepath.Dir(dstPath), 0755); err != nil {
+		return nil, err
+	}
+
+	tmpPath := filepath.Join(filepath.Dir(dstPath), "."+filepath.Base(dstPath)+".tmp")
+	out, err := os.Create(tmpPath)
+	if err != nil {
+		return nil, err
+	}
+	hash := md5.New()
+	writer := bufio.NewWriterSize(io.MultiWriter(out, hash), 1*1024*1024)
+
+	var count int64
+	var genErr error
+	for _, w := range words {
+		if ctx.Err() != nil {
+			genErr = ctx.Err()
+			break
+		}
+		if w == "" {
+			continue
+		}
+		// One candidate per line, normalized to '\n' endings.
+		if _, werr := writer.WriteString(w); werr != nil {
+			genErr = werr
+			break
+		}
+		if werr := writer.WriteByte('\n'); werr != nil {
+			genErr = werr
+			break
+		}
+		count++
+	}
+	if genErr == nil {
+		if ferr := writer.Flush(); ferr != nil {
+			genErr = ferr
+		}
+	}
+	if cerr := out.Close(); cerr != nil && genErr == nil {
+		genErr = cerr
+	}
+	if genErr != nil {
+		os.Remove(tmpPath)
+		if isNoSpaceErr(genErr) {
+			return nil, fmt.Errorf("ran out of disk space while materializing loopback wordlist: %w", genErr)
+		}
+		return nil, genErr
+	}
+	if count == 0 {
+		os.Remove(tmpPath)
+		return nil, fmt.Errorf("cannot materialize an empty wordlist (all words were blank)")
+	}
+	if err := os.Rename(tmpPath, dstPath); err != nil {
+		os.Remove(tmpPath)
+		return nil, err
+	}
+
+	var size int64
+	if info, statErr := os.Stat(dstPath); statErr == nil {
+		size = info.Size()
+	}
+
+	owner := ownerJobID
+	wl := &models.Wordlist{
+		Name:               name,
+		WordlistType:       "custom",
+		Format:             string(models.WordlistFormatPlaintext),
+		FileName:           fileName,
+		MD5Hash:            hex.EncodeToString(hash.Sum(nil)),
+		FileSize:           size,
+		WordCount:          count,
+		CreatedBy:          userID,
+		VerificationStatus: "verified",
+		IsEphemeral:        true,
+		OwnerJobID:         &owner,
+	}
+	if err := m.store.CreateWordlist(ctx, wl); err != nil {
+		os.Remove(dstPath)
+		return nil, err
+	}
+	debug.Info("Materialized ephemeral loopback wordlist %d (%s): %d words", wl.ID, fileName, count)
+	return wl, nil
 }
 
 // GenerateFilteredWordlist (re)materializes a filtered wordlist from its parent

--- a/docs/admin-guide/operations/job-settings.md
+++ b/docs/admin-guide/operations/job-settings.md
@@ -241,6 +241,31 @@ WHERE key = 'hashlist_bulk_batch_size';
 - **Memory Usage**: Roughly linear with batch size (~10MB per 100,000 hashes)
 - **Database Load**: Larger batches create fewer but larger transactions
 
+#### Loopback Round Cap
+
+The `loopback_max_rounds` setting caps how many delta rounds a [loopback](../../user-guide/loopback.md) session runs before it stops, even if new cracks keep appearing. It is a safety bound — most sessions go "dry" (a round finds nothing new) well before the cap.
+
+| Setting | Description | Default | Notes |
+|---------|-------------|---------|-------|
+| **`loopback_max_rounds`** | Maximum delta rounds per loopback session | 10 | Applied when a session is created |
+
+The value is read when a session starts; changing it affects **new** sessions, not ones already in flight. If the setting is missing, the backend falls back to 10.
+
+```sql
+-- View current setting
+SELECT key, value, description
+FROM system_settings
+WHERE key = 'loopback_max_rounds';
+
+-- Raise the cap (example: allow up to 25 rounds)
+UPDATE system_settings
+SET value = '25'
+WHERE key = 'loopback_max_rounds';
+```
+
+See [Loopback](../../user-guide/loopback.md) for how sessions work and the
+[Loopback Sessions architecture](../../reference/architecture/loopback.md) reference for internals.
+
 ### Rule Splitting
 
 Rule splitting automatically divides large rule files to improve distribution across agents. This is especially useful for rule files that would otherwise exceed the chunk duration.

--- a/docs/reference/architecture/loopback.md
+++ b/docs/reference/architecture/loopback.md
@@ -1,0 +1,161 @@
+# Loopback Sessions
+
+## Overview
+
+**Loopback** (GH #64) re-runs the *mutating* part of an attack against only the
+newly-cracked plaintexts (the "delta"), repeating until a round produces no new plaintext.
+It exists because "run this preset again in a workflow" would re-try the whole wordlist for a
+handful of new candidates; loopback instead loops the mutation over just the delta, so each
+round is cheap and the loop terminates on its own.
+
+The original GitHub issue asked to allow the same preset job multiple times in a workflow.
+That was resolved **not** by permitting duplicates, but by this delta-only re-run mechanism.
+
+## Concepts
+
+### Eligibility
+
+`models.IsMutatableAttack(mode, ruleIDs)` decides whether an attack's mutation can be re-run
+against a delta wordlist:
+
+| Attack mode | Mutatable | Rationale |
+| --- | --- | --- |
+| Straight (0) **with** rules | ✅ | The rules are the mutation → `delta × rules` |
+| Hybrid wordlist+mask (6) | ✅ | The mask is the mutation → `delta + mask` |
+| Hybrid mask+wordlist (7) | ✅ | The mask is the mutation → `mask + delta` |
+| Straight (0) **without** rules | ❌ | The word was already tried verbatim |
+| Brute-force (3) | ❌ | No wordlist to swap the delta into |
+| Combination (1) | ❌ | No single, clean "mutation" side |
+| Association (9) | ❌ | 1:1 hash↔word mapping, no loopback semantics |
+
+Ineligible jobs are **not** re-run, but their cracks still feed the delta pool that eligible
+lineages loop on.
+
+### The delta
+
+For each round, the delta is the set of **distinct new plaintexts cracked by the session's
+own jobs** that have not yet been used as loopback input for this session:
+
+- Cracks are scoped to the session via `hashes.cracked_by_task_id` → `job_tasks` →
+  `loopback_session_jobs`, so only *this* session's work contributes.
+- A per-session guard set, `loopback_session_plaintexts` (the md5 of each plaintext already
+  used as input), subtracts candidates that were fed in a previous round.
+
+Because every distinct plaintext is consumed **exactly once**, the loop is guaranteed to
+terminate: a round is either strictly smaller than the pool of not-yet-tried cracks, or empty
+(dry) — at which point the session completes.
+
+The delta is read straight from the `hashes` table (synchronous), so a potfile flush is
+**not** required before a round can start.
+
+## Session Lifecycle
+
+A **session** is one loopback group: a workflow run, or a standalone preset/custom run.
+
+```
+waiting ──▶ active ──▶ completed
+   │           │
+   └──────┬────┴──────▶ failed / cancelled
+```
+
+| Status | Meaning |
+| --- | --- |
+| `waiting` | Round-0 (original) jobs are still running; controller is waiting for them to reach a terminal state |
+| `active` | At least one delta round has been spawned; controller is monitoring the current round |
+| `completed` | A round came back dry, or `max_rounds` was reached |
+| `failed` | The session errored (see `error_message`) |
+| `cancelled` | The session was cancelled |
+
+### The controller / monitor
+
+`services.LoopbackService` is a **durable** controller — it survives a backend restart
+because each tick re-queries the `waiting`/`active` sessions from the database rather than
+holding them in memory (unlike the transient `preparing` job state, which is failed on
+restart). It is started once via a `sync.Once` in `routes/user.go` `CreateJobsHandler`.
+
+An **idle-gated poller** (≈7 s) checks `LoopbackRepository.HasActiveSessions` — backed by a
+partial index on `loopback_sessions(status) WHERE status IN ('waiting','active')` — so it
+costs almost nothing when no sessions are in flight.
+
+On each tick, for a session whose current round's jobs are all terminal:
+
+1. Stop early if the hashlist is already fully cracked (`HashlistHasUncracked`) — no wasted
+   round against an exhausted list.
+2. Compute the delta.
+3. If the delta is empty → **complete** the session (dry).
+4. Otherwise spawn one re-run per mutatable lineage and advance the round.
+
+Re-runs reuse the pre-filter job path (`CreatePreparingFilterJob` → materialize the
+ephemeral delta wordlist → `FinalizeFilterJob`). They are ordinary `job_executions`, so the
+scheduler, agents, and progress tracking are entirely unchanged — the loopback layer only
+decides *what* to enqueue and *when*.
+
+!!! note "Session creation is transactional"
+    `CreateSessionWithJobs` inserts the session and links its round-0 jobs in one transaction,
+    closing a race where the monitor could observe a session before its round-0 jobs were
+    linked and prematurely complete it as dry.
+
+### Delta wordlist materialization
+
+`wordlist.Manager.MaterializeEphemeralWordlist([]string, …)` writes the delta to a
+`custom/__eph__*.txt` wordlist flagged `is_ephemeral` with an `owner_job_id`, inheriting the
+[wordlist filtering](../../user-guide/wordlist-filtering.md) cleanup lifecycle. (This differs
+from the GH #40 materializer, which *filters a parent* wordlist rather than writing an
+explicit line set.)
+
+## Configuration
+
+Loopback config lives on the workflow or at job-start time — **never** on the preset job
+definition:
+
+| Location | Field / control |
+| --- | --- |
+| `job_workflows.loopback_all_eligible` | Master toggle: loop every eligible step. When true, per-step flags are ignored. |
+| `job_workflow_steps.loopback_enabled` | Per-step toggle, used only when the workflow master toggle is off. |
+| Create-job request (`loopback`) | Standalone preset/custom runs carry the toggle in the request payload. |
+
+The create-job wiring is in `handlers/jobs/user_jobs.go` `CreateJobFromHashlist`: preset and
+custom runs read the request `loopback` flag; workflow runs read the step/master flags. The
+frontend surfaces are `JobWorkflowForm.tsx` (workflow builder — master + per-step, eligibility
+aware), `CreateJobDialog.tsx` (per-run toggle on the Preset and Custom tabs; a "Loopback"
+badge on the Workflow tab), and `components/jobs/LoopbackSessionsPanel.tsx` (the monitoring
+panel on the Jobs page and Dashboard, backed by `GET /api/loopback-sessions`).
+
+### `loopback_max_rounds`
+
+A `system_settings` row (`loopback_max_rounds`, default `10`, integer) caps how many delta
+rounds a session runs before it stops, even if new cracks keep appearing. It is resolved when
+a session is created (`resolveMaxRounds`), falling back to `defaultLoopbackMaxRounds = 10` if
+the setting is missing. See [Job Settings](../../admin-guide/operations/job-settings.md#loopback-round-cap).
+
+## Schema
+
+Migration `20260717120000_add_loopback`:
+
+- `job_workflows.loopback_all_eligible BOOLEAN` — workflow master toggle.
+- `job_workflow_steps.loopback_enabled BOOLEAN` — per-step toggle.
+- **`loopback_sessions`** — one row per session (`hashlist_id`, `source_type`
+  workflow/preset/custom, `source_workflow_id`, `status`, `current_round`, `max_rounds`,
+  `created_by`). Partial index on the in-flight statuses for the monitor's idle gate.
+- **`loopback_session_jobs`** — links each `job_execution` to a session per `round`, with a
+  `role` (`original` | `rerun`), `is_mutatable`, and `origin_job_id` (the round-0 job a
+  lineage descends from). `round 0` = original jobs; `round >= 1` = controller re-runs.
+- **`loopback_session_plaintexts`** — the per-session used-set (`plaintext_md5`) that
+  guarantees each plaintext is fed exactly once.
+- `system_settings` row `loopback_max_rounds` (default `10`).
+
+## Scope and caveats (v1)
+
+- Custom loopback is **not** combined with the GH #40 wordlist filter — the two are mutually
+  exclusive in the UI.
+- Combination (`-a 1`) and association (`-a 9`) are intentionally excluded.
+- Only the UI create-job path (`user_jobs.go`) creates sessions; the programmatic `api/v1`
+  job-create path does **not** start loopback sessions.
+
+## Related
+
+- [Loopback (user guide)](../../user-guide/loopback.md)
+- [Increment Mode](increment-mode.md)
+- [Job Completion System](job-completion-system.md)
+- [Wordlist Filtering](../../user-guide/wordlist-filtering.md)
+- [Scheduler v2 Overview](scheduler-v2-overview.md)

--- a/docs/user-guide/jobs-workflows.md
+++ b/docs/user-guide/jobs-workflows.md
@@ -155,6 +155,18 @@ Hash 1 is tested against "user1birthday2020", hash 2 against "user2petname!", et
 
 See [Association Wordlists](hashlists.md#association-wordlists-v140) for how to upload and manage association wordlists.
 
+## Loopback: Re-run Against New Cracks
+
+For rule-based and hybrid attacks, KrakenHashes can automatically feed the passwords an
+attack just cracked back into its mutation — applying your rules or hybrid mask to only the
+**newly-cracked** plaintexts, round after round, until nothing new turns up. It's a cheap way
+to catch pattern reuse (`Summer2024` → `Summer2024!`) without re-running the whole wordlist.
+
+Enable it with the **"Loopback until dry"** toggle when launching a preset or custom job, or
+configure it on a workflow so eligible steps loop automatically.
+
+See [Loopback](loopback.md) for the full guide.
+
 ## Understanding Priorities
 
 Jobs within workflows run in priority order:

--- a/docs/user-guide/loopback.md
+++ b/docs/user-guide/loopback.md
@@ -1,0 +1,127 @@
+# Loopback: Re-run Against New Cracks
+
+## Quick Overview
+
+**Loopback** takes the passwords an attack just cracked and feeds them straight back into
+the *mutating* part of that same attack — automatically, over and over, until a pass finds
+nothing new.
+
+The idea comes from a simple observation: people reuse patterns. If `Summer2024` cracked,
+then `Summer2024!`, `Summer2024#`, or `summer2024` are good guesses for the *next* hash. A
+loopback applies your rules (or a hybrid mask) to the freshly-cracked plaintexts only — a
+tiny, high-value candidate set — instead of re-running the whole wordlist.
+
+!!! tip "Why not just add the attack to a workflow twice?"
+    Running the same attack again re-tries the *entire* wordlist for a handful of new
+    candidates. Loopback re-runs the mutation against **only** the newly-cracked passwords
+    (the "delta"), so each round is small and fast, and the loop stops on its own once it
+    goes dry.
+
+## How It Works
+
+1. Your attack runs normally and cracks some hashes.
+2. When it finishes, KrakenHashes collects the **delta** — the distinct new plaintexts that
+   *this run* cracked.
+3. It re-runs the attack's **mutation** against just those plaintexts:
+    - **Straight + rules** → the delta words × your rules
+    - **Hybrid (wordlist + mask / mask + wordlist)** → the delta words ± your mask
+4. Any hashes cracked in that round become the *next* delta, and the process repeats.
+5. The session stops when a round produces **no new plaintext** ("dry"), when the whole
+   hashlist is cracked, or when the safety cap on rounds is reached.
+
+Each distinct plaintext is used as loopback input **exactly once**, so the loop is
+guaranteed to terminate — it can never re-try the same candidate twice.
+
+### What's eligible
+
+Loopback only makes sense for attacks that have a *mutation* separable from the wordlist:
+
+| Attack | Eligible? | Behavior |
+| --- | --- | --- |
+| Straight (dictionary) **with rules** | ✅ Yes | Delta words re-run through the rules |
+| Hybrid wordlist + mask (`-a 6`) | ✅ Yes | Delta words re-run with the mask appended |
+| Hybrid mask + wordlist (`-a 7`) | ✅ Yes | Delta words re-run with the mask prepended |
+| Straight **without rules** | ❌ No | The word was already tried as-is — nothing to mutate |
+| Brute-force / mask (`-a 3`) | ❌ No | No wordlist to feed the delta into |
+| Combination (`-a 1`) | ❌ No | No single "mutation" side |
+| Association (`-a 9`) | ❌ No | 1:1 hash↔word mapping — no loopback semantics |
+
+!!! note "Ineligible steps still contribute"
+    In a workflow, an ineligible step (say, a brute-force step) isn't re-run, but the new
+    passwords **it** cracks are still added to the delta pool that the eligible steps loop
+    on. Nothing a step cracks is wasted.
+
+## Turning Loopback On
+
+There are three places to enable loopback, depending on how you launch the attack.
+
+### 1. In a Workflow (admin)
+
+When building or editing a **Job Workflow** (Admin → Preset Jobs & Workflows):
+
+- **Enable loopback for all eligible steps** — a master toggle at the top of the workflow
+  form. When on, every eligible step in the workflow loops back, and the per-step checkboxes
+  are ignored.
+- **Per-step "Loopback"** — a checkbox on each step, used only while the master toggle is
+  **off**. It's disabled (with an explanatory tooltip) for ineligible steps.
+
+A workflow that has loopback configured shows a **"Loopback: all eligible"** badge in the
+create-job dialog so operators know it will loop automatically — there's nothing extra to
+turn on at run time.
+
+### 2. On a Preset Job run
+
+In the **Create Job** dialog's **Preset** tab, a **"Loopback until dry"** toggle appears
+above the preset list. It enables once you've selected an eligible preset (straight + rules,
+or a hybrid attack). The selected job runs, then its mutation loops against the new cracks.
+
+### 3. On a Custom job run
+
+In the **Create Job** dialog's **Custom** tab, a **"Loopback until dry"** toggle appears for
+eligible attacks (rules or a hybrid mask).
+
+!!! warning "Loopback and pre-filtering are mutually exclusive"
+    On a custom job you can use **either** wordlist [pre-filtering](wordlist-filtering.md)
+    **or** loopback, not both at once. The loopback toggle is unavailable while pre-filtering
+    is enabled for that job.
+
+## Watching a Loopback Run
+
+While any loopback is in flight, a **Loopback** panel appears on both the **Jobs** page and
+the **Dashboard**. It hides itself when there's nothing running.
+
+Each session shows:
+
+- Its **name** and a **source** chip — `workflow`, `preset`, or `custom`.
+- A **status** chip:
+
+    | Status | Meaning |
+    | --- | --- |
+    | **Waiting for round to finish** | The current round's jobs are still running |
+    | **Looping** | A delta round has been spawned and is being monitored |
+    | **Done** | A round came back dry (or the round cap was hit) — the loop finished |
+    | **Failed** | The session hit an error (see the tooltip) |
+    | **Cancelled** | The session was cancelled |
+
+- **Round X / Y** — the current round and the configured safety cap.
+- The number of jobs in the session, expandable to see each round's jobs and their status.
+
+Loopback re-runs are ordinary jobs, so they also appear in the normal Jobs list with their
+own progress bars, priority, and agent assignment — the panel just ties them together.
+
+!!! note "Sessions survive a restart"
+    The loopback controller is durable: if the backend restarts while a session is waiting on
+    a long round, the session resumes rather than being lost.
+
+## The Round Cap
+
+Every session has a safety cap on how many delta rounds it will run, even if new cracks keep
+appearing. The default is **10 rounds**. Administrators can change it — see
+[Job Settings](../admin-guide/operations/job-settings.md#loopback-round-cap). In practice
+most sessions go dry well before the cap.
+
+## Related
+
+- [Jobs and Workflows](jobs-workflows.md)
+- [Wordlist Filtering](wordlist-filtering.md)
+- [Loopback architecture](../reference/architecture/loopback.md) (how it works internally)

--- a/frontend/src/components/hashlist/CreateJobDialog.tsx
+++ b/frontend/src/components/hashlist/CreateJobDialog.tsx
@@ -65,14 +65,24 @@ interface JobWorkflow {
   name: string;
   description?: string;
   has_high_priority_override?: boolean;
+  loopback_all_eligible?: boolean; // GH #64
   steps?: Array<{
     id: number;
     preset_job_id: string;
     step_order: number;
     preset_job_name?: string;
     allow_high_priority_override?: boolean;
+    loopback_enabled?: boolean; // GH #64
   }>;
 }
+
+// A loopback re-runs an attack's mutation against only the newly-cracked plaintexts.
+// Eligible: straight (0) WITH rules, or a hybrid (6/7) with a mask. Everything else
+// (wordlist-only, brute-force, combinator, association) is not re-run (GH #64).
+const isLoopbackEligibleMode = (attackMode: number, ruleIds?: string[]): boolean => {
+  if (attackMode === 0) return !!ruleIds && ruleIds.length > 0;
+  return attackMode === 6 || attackMode === 7;
+};
 
 interface ClientWordlist {
   id: string;
@@ -176,6 +186,10 @@ export default function CreateJobDialog({
   // Ephemeral wordlist filtering (GH #40) — applies to wordlist-based attacks only.
   const [filterEnabled, setFilterEnabled] = useState(false);
   const [customFilter, setCustomFilter] = useState<WordlistFilter>({});
+
+  // Loopback (GH #64) — per-run toggle for preset and custom jobs.
+  const [presetLoopback, setPresetLoopback] = useState(false);
+  const [customLoopback, setCustomLoopback] = useState(false);
 
   // Saved charsets for picker
   const [savedCharsets, setSavedCharsets] = useState<CustomCharset[]>([]);
@@ -304,7 +318,8 @@ export default function CreateJobDialog({
         payload = {
           type: 'preset',
           preset_job_ids: selectedPresetJobs,
-          custom_job_name: customJobName
+          custom_job_name: customJobName,
+          loopback: presetLoopback
         };
       } else if (tabValue === 2) {
         // Custom job
@@ -370,6 +385,13 @@ export default function CreateJobDialog({
         // Attach an ephemeral wordlist filter for wordlist-based attacks (GH #40).
         if (filterEnabled && [0, 1, 6, 7].includes(customJob.attack_mode) && !isFilterEmpty(customFilter)) {
           customJobPayload.filter = customFilter;
+        }
+
+        // Loopback (GH #64): re-run the mutation against newly-cracked plaintexts until
+        // dry. Not combined with the ephemeral filter (the filter path is a no-op for
+        // loopback), and only meaningful for mutatable attacks.
+        if (customLoopback && !filterEnabled && isLoopbackEligibleMode(customJob.attack_mode, customJob.rule_ids)) {
+          customJobPayload.loopback = true;
         }
 
         payload = {
@@ -450,6 +472,9 @@ export default function CreateJobDialog({
       // Reset ephemeral filter state
       setFilterEnabled(false);
       setCustomFilter({});
+      // Reset loopback state (GH #64)
+      setPresetLoopback(false);
+      setCustomLoopback(false);
       // Reset combination wordlist state
       setCombWordlist1('');
       setCombWordlist2('');
@@ -526,6 +551,7 @@ export default function CreateJobDialog({
                     />
                     <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
                       Select one or more workflows to run. You can select multiple workflows - each will create its own sequence of job executions.
+                      Loopback settings are configured in the workflow itself — a workflow tagged “Loopback” will automatically re-run its eligible steps against newly-cracked passwords.
                     </Typography>
                     <List>
                       {workflows.map((workflow) => (
@@ -561,6 +587,15 @@ export default function CreateJobDialog({
                                     label={`${workflow.steps?.length || 0} jobs`}
                                     sx={{ mr: 1 }}
                                   />
+                                  {workflow.loopback_all_eligible && (
+                                    <Chip
+                                      size="small"
+                                      color="secondary"
+                                      variant="outlined"
+                                      label="Loopback: all eligible"
+                                      sx={{ mr: 1 }}
+                                    />
+                                  )}
                                   {workflow.has_high_priority_override && (
                                     <Chip
                                       size="small"
@@ -610,6 +645,35 @@ export default function CreateJobDialog({
                     <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
                       Select one or more preset jobs to run. You can select multiple jobs - they will be created as separate job executions.
                     </Typography>
+                    {/* Loopback toggle (GH #64) kept ABOVE the preset list so it's visible
+                        without scrolling past a long list. Enables once an eligible preset
+                        (straight + rules, or a hybrid) is selected. */}
+                    {(() => {
+                      const anyEligible = selectedPresetJobs.some(id => {
+                        const p = presetJobs.find(j => j.id === id);
+                        return p ? isLoopbackEligibleMode(p.attack_mode, p.rule_ids) : false;
+                      });
+                      const helper = anyEligible
+                        ? 'Runs the selected job(s), then re-runs the mutatable ones (straight + rules, or a hybrid attack) against only the newly-cracked passwords — repeating until no new cracks are found.'
+                        : selectedPresetJobs.length === 0
+                          ? 'Select an eligible preset (straight + rules, or a hybrid attack) below to enable loopback.'
+                          : 'None of the selected jobs have a mutation to loop back (they are wordlist-only, brute-force or association).';
+                      return (
+                        <Box sx={{ mb: 2, p: 2, borderRadius: 1, bgcolor: 'action.hover' }}>
+                          <FormControlLabel
+                            control={
+                              <Checkbox
+                                checked={presetLoopback && anyEligible}
+                                disabled={!anyEligible}
+                                onChange={(e) => setPresetLoopback(e.target.checked)}
+                              />
+                            }
+                            label="Loopback until dry"
+                          />
+                          <FormHelperText>{helper}</FormHelperText>
+                        </Box>
+                      );
+                    })()}
                     <List>
                       {presetJobs.map((job) => (
                         <ListItem
@@ -1121,6 +1185,27 @@ export default function CreateJobDialog({
                           />
                         </Box>
                       )}
+                    </Grid>
+                  )}
+
+                  {/* Loopback (GH #64) - mutatable attacks only */}
+                  {isLoopbackEligibleMode(customJob.attack_mode, customJob.rule_ids) && (
+                    <Grid item xs={12}>
+                      <FormControlLabel
+                        control={
+                          <Checkbox
+                            checked={customLoopback && !filterEnabled}
+                            disabled={filterEnabled}
+                            onChange={(e) => setCustomLoopback(e.target.checked)}
+                          />
+                        }
+                        label="Loopback until dry"
+                      />
+                      <FormHelperText>
+                        {filterEnabled
+                          ? 'Loopback is unavailable while pre-filtering is enabled for this job.'
+                          : 'Runs this attack, then re-runs its mutation (rules or mask) against only the newly-cracked passwords — repeating until no new cracks are found.'}
+                      </FormHelperText>
                     </Grid>
                   )}
 

--- a/frontend/src/components/jobs/LoopbackSessionsPanel.tsx
+++ b/frontend/src/components/jobs/LoopbackSessionsPanel.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  Paper,
+  Box,
+  Typography,
+  Chip,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tooltip,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import LoopIcon from '@mui/icons-material/Loop';
+import { getLoopbackSessions } from '../../services/api';
+import { LoopbackSession, LoopbackSessionStatus } from '../../types/adminJobs';
+
+const STATUS_COLOR: Record<LoopbackSessionStatus, 'default' | 'info' | 'primary' | 'success' | 'error'> = {
+  waiting: 'info',
+  active: 'primary',
+  completed: 'success',
+  failed: 'error',
+  cancelled: 'default',
+};
+
+const STATUS_LABEL: Record<LoopbackSessionStatus, string> = {
+  waiting: 'Waiting for round to finish',
+  active: 'Looping',
+  completed: 'Done',
+  failed: 'Failed',
+  cancelled: 'Cancelled',
+};
+
+// A loopback session is "in flight" while waiting or active.
+const isInFlight = (s: LoopbackSession) => s.status === 'waiting' || s.status === 'active';
+
+/**
+ * LoopbackSessionsPanel shows loopback sessions (GH #64) — each one links a workflow /
+ * preset / custom run to the delta re-runs it spawns. It polls alongside the jobs table
+ * and renders nothing when there are no sessions to show.
+ */
+const LoopbackSessionsPanel: React.FC<{ pollIntervalMs?: number }> = ({ pollIntervalMs = 5000 }) => {
+  const [sessions, setSessions] = useState<LoopbackSession[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  const fetchSessions = useCallback(async () => {
+    try {
+      const data = await getLoopbackSessions();
+      setSessions(data);
+    } catch (e) {
+      // Non-fatal: the panel simply stays hidden/stale.
+    } finally {
+      setLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSessions();
+    const id = setInterval(fetchSessions, pollIntervalMs);
+    return () => clearInterval(id);
+  }, [fetchSessions, pollIntervalMs]);
+
+  // Only surface sessions that are in flight or ended recently-ish; hide the panel
+  // entirely when there's nothing to show to avoid clutter.
+  const visible = sessions
+    .slice()
+    .sort((a, b) => {
+      // In-flight first, then most recent.
+      if (isInFlight(a) !== isInFlight(b)) return isInFlight(a) ? -1 : 1;
+      return b.created_at.localeCompare(a.created_at);
+    });
+
+  if (!loaded || visible.length === 0) {
+    return null;
+  }
+
+  const inFlightCount = visible.filter(isInFlight).length;
+
+  return (
+    <Paper sx={{ p: 2, mb: 3 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+        <LoopIcon color="primary" />
+        <Typography variant="h6">Loopback</Typography>
+        <Chip size="small" label={`${inFlightCount} active`} color={inFlightCount > 0 ? 'primary' : 'default'} />
+      </Box>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Each loopback re-runs an attack's mutation against only the newly-cracked passwords,
+        repeating until no new cracks are found.
+      </Typography>
+
+      {visible.map((session) => (
+        <Accordion key={session.id} disableGutters defaultExpanded={isInFlight(session)}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', width: '100%' }}>
+              <Typography sx={{ fontWeight: 500 }}>{session.name}</Typography>
+              <Chip size="small" variant="outlined" label={session.source_type} />
+              <Tooltip title={session.error_message || STATUS_LABEL[session.status]}>
+                <Chip size="small" color={STATUS_COLOR[session.status]} label={session.status} />
+              </Tooltip>
+              <Chip size="small" variant="outlined" label={`Round ${session.current_round} / ${session.max_rounds}`} />
+              <Box sx={{ flexGrow: 1 }} />
+              <Typography variant="caption" color="text.secondary">
+                {session.jobs?.length ?? 0} job(s)
+              </Typography>
+            </Box>
+          </AccordionSummary>
+          <AccordionDetails>
+            {session.jobs && session.jobs.length > 0 ? (
+              <Box sx={{ overflowX: 'auto' }}>
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Round</TableCell>
+                      <TableCell>Job</TableCell>
+                      <TableCell>Role</TableCell>
+                      <TableCell>Loops back</TableCell>
+                      <TableCell>Status</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {session.jobs
+                      .slice()
+                      .sort((a, b) => a.round - b.round)
+                      .map((job) => (
+                        <TableRow key={job.id}>
+                          <TableCell>{job.round === 0 ? 'Original' : job.round}</TableCell>
+                          <TableCell>{job.job_name || job.job_execution_id}</TableCell>
+                          <TableCell>{job.role}</TableCell>
+                          <TableCell>{job.is_mutatable ? 'Yes' : 'Feeds delta'}</TableCell>
+                          <TableCell>{job.job_status || '—'}</TableCell>
+                        </TableRow>
+                      ))}
+                  </TableBody>
+                </Table>
+              </Box>
+            ) : (
+              <Typography variant="body2" color="text.secondary">
+                No jobs recorded yet.
+              </Typography>
+            )}
+          </AccordionDetails>
+        </Accordion>
+      ))}
+    </Paper>
+  );
+};
+
+export default LoopbackSessionsPanel;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -80,6 +80,7 @@ import { calculateJobProgress, formatKeyspace } from '../utils/jobProgress';
 import { formatHashRate } from '../utils/formatters';
 import { useNavigate } from 'react-router-dom';
 import HashlistOverview from '../components/dashboard/HashlistOverview';
+import LoopbackSessionsPanel from '../components/jobs/LoopbackSessionsPanel';
 // import JobStatusMonitor from '../components/JobStatusMonitor'; // Removed to improve page load performance
 
 /**
@@ -482,7 +483,12 @@ const Dashboard: React.FC = () => {
             </Typography>
           </Grid>
           {gridItems}
-          
+
+          {/* Loopback sessions (GH #64) — renders nothing when there are none */}
+          <Grid item xs={12}>
+            <LoopbackSessionsPanel />
+          </Grid>
+
           <Grid item xs={12}>
             <Divider sx={{ my: 2 }} />
             <Typography variant="h5" component="h2" gutterBottom>

--- a/frontend/src/pages/Jobs/index.tsx
+++ b/frontend/src/pages/Jobs/index.tsx
@@ -36,6 +36,7 @@ import {
 import { useSnackbar } from 'notistack';
 import JobsTable from './JobsTable';
 import DeleteConfirm from './DeleteConfirm';
+import LoopbackSessionsPanel from '../../components/jobs/LoopbackSessionsPanel';
 import { api, archiveJob, unarchiveJob } from '../../services/api';
 import { JobSummary, PaginationInfo } from '../../types/jobs';
 import { useTeamFilter } from '../../contexts/TeamFilterContext';
@@ -536,6 +537,9 @@ const Jobs: React.FC = () => {
           {filters.status || filters.priority !== null || filters.search ? ` ${t('filtered') as string}` : ''}
         </Typography>
       )}
+
+      {/* Loopback sessions (GH #64) — renders nothing when there are none */}
+      <LoopbackSessionsPanel />
 
       {/* Jobs Table */}
       <Paper sx={{ width: '100%', overflow: 'hidden' }}>

--- a/frontend/src/pages/admin/JobWorkflowForm.tsx
+++ b/frontend/src/pages/admin/JobWorkflowForm.tsx
@@ -23,7 +23,11 @@ import {
   Grid,
   Autocomplete,
   Chip,
-  Stack
+  Stack,
+  Switch,
+  Checkbox,
+  FormControlLabel,
+  Tooltip
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AddIcon from '@mui/icons-material/Add';
@@ -37,12 +41,13 @@ import {
   createJobWorkflow, 
   updateJobWorkflow 
 } from '../../services/api';
-import { 
-  PresetJobBasic, 
-  JobWorkflowFormData, 
+import {
+  PresetJobBasic,
+  JobWorkflowFormData,
   CreateWorkflowRequest,
   AttackMode,
-  JobWorkflowStep
+  JobWorkflowStep,
+  isLoopbackEligible
 } from '../../types/adminJobs';
 
 // Helper function to get attack mode display name
@@ -68,7 +73,9 @@ const JobWorkflowFormPage: React.FC = () => {
   const [formData, setFormData] = useState<JobWorkflowFormData>({
     name: '',
     preset_job_ids: [],
-    orderedJobs: []
+    orderedJobs: [],
+    loopback_all_eligible: false,
+    loopback_preset_job_ids: []
   });
 
   // Store detailed workflow steps separately
@@ -123,22 +130,31 @@ const JobWorkflowFormPage: React.FC = () => {
               
               setWorkflowSteps(sortedSteps);
               
-              // Create mapping of IDs to names for rendering
+              // Create mapping of IDs to names for rendering (carrying attack mode +
+              // rules so loopback eligibility can be computed client-side).
               const orderedJobs: PresetJobBasic[] = sortedSteps.map(step => ({
                 id: step.preset_job_id,
-                name: step.preset_job_name
+                name: step.preset_job_name,
+                attack_mode: step.preset_job_attack_mode,
+                rule_ids: step.preset_job_rule_ids
               }));
-              
+
               setFormData({
                 name: workflow.name,
                 preset_job_ids: sortedSteps.map(step => step.preset_job_id),
-                orderedJobs
+                orderedJobs,
+                loopback_all_eligible: workflow.loopback_all_eligible ?? false,
+                loopback_preset_job_ids: sortedSteps
+                  .filter(step => step.loopback_enabled)
+                  .map(step => step.preset_job_id)
               });
             } else {
               setFormData({
                 name: workflow.name,
                 preset_job_ids: [],
-                orderedJobs: []
+                orderedJobs: [],
+                loopback_all_eligible: workflow.loopback_all_eligible ?? false,
+                loopback_preset_job_ids: []
               });
             }
           } catch (err) {
@@ -202,9 +218,26 @@ const JobWorkflowFormPage: React.FC = () => {
       return {
         ...prev,
         preset_job_ids: newPresetJobIds,
-        orderedJobs: newOrderedJobs
+        orderedJobs: newOrderedJobs,
+        loopback_preset_job_ids: prev.loopback_preset_job_ids.filter(id => id !== jobId)
       };
     });
+  };
+
+  // Toggle the workflow-level master loopback (GH #64). Mutually exclusive with the
+  // per-step toggles: while this is on, per-step checkboxes are disabled.
+  const handleToggleMasterLoopback = (checked: boolean) => {
+    setFormData(prev => ({ ...prev, loopback_all_eligible: checked }));
+  };
+
+  // Toggle per-step loopback for a preset (only used while the master toggle is off).
+  const handleToggleStepLoopback = (presetId: string, checked: boolean) => {
+    setFormData(prev => ({
+      ...prev,
+      loopback_preset_job_ids: checked
+        ? [...prev.loopback_preset_job_ids, presetId]
+        : prev.loopback_preset_job_ids.filter(id => id !== presetId)
+    }));
   };
 
   // Handle drag end for reordering workflow steps
@@ -256,10 +289,16 @@ const JobWorkflowFormPage: React.FC = () => {
     setError(null);
     setSuccessMessage(null);
     
-    // Create request payload (only need name and preset_job_ids)
+    // Create request payload
     const payload: CreateWorkflowRequest = {
       name: formData.name,
-      preset_job_ids: formData.preset_job_ids
+      preset_job_ids: formData.preset_job_ids,
+      loopback_all_eligible: formData.loopback_all_eligible,
+      // Only send per-step loopback selections when the master toggle is off (they are
+      // ignored otherwise); keep only IDs still present in the workflow.
+      loopback_preset_job_ids: formData.loopback_all_eligible
+        ? []
+        : formData.loopback_preset_job_ids.filter(id => formData.preset_job_ids.includes(id))
     };
     
     try {
@@ -330,6 +369,26 @@ const JobWorkflowFormPage: React.FC = () => {
             disabled={submitting}
           />
 
+          <Box mt={3} sx={{ p: 2, borderRadius: 1, bgcolor: 'action.hover' }}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={formData.loopback_all_eligible}
+                  onChange={(e) => handleToggleMasterLoopback(e.target.checked)}
+                  disabled={submitting}
+                />
+              }
+              label="Enable loopback for all eligible steps"
+            />
+            <FormHelperText sx={{ mt: 0 }}>
+              When on, the whole workflow runs, then every eligible step (straight&nbsp;+&nbsp;rules,
+              or a hybrid&nbsp;wordlist&nbsp;±&nbsp;mask attack) re-runs against only the newly-cracked
+              passwords — repeating intelligently until no new cracks are found. Non-mutating steps
+              (wordlist-only, brute-force, association) still feed their new cracks into the loop.
+              The per-step toggles below are disabled while this is on.
+            </FormHelperText>
+          </Box>
+
           <Box mt={3}>
             <Autocomplete
               options={availablePresetJobs.filter(job => !formData.preset_job_ids.includes(job.id))}
@@ -365,6 +424,17 @@ const JobWorkflowFormPage: React.FC = () => {
                       {formData.orderedJobs.map((job, index) => {
                         // Find the corresponding workflow step for detailed info
                         const workflowStep = workflowSteps.find(step => step.preset_job_id === job.id);
+
+                        // Loopback eligibility + state (GH #64)
+                        const eligible = isLoopbackEligible(job.attack_mode, job.rule_ids);
+                        const masterOn = formData.loopback_all_eligible;
+                        const loopbackChecked = masterOn ? eligible : formData.loopback_preset_job_ids.includes(job.id);
+                        const loopbackDisabled = masterOn || !eligible || submitting;
+                        const loopbackTooltip = !eligible
+                          ? 'Nothing to mutate (wordlist-only, brute-force, association or combinator). This step still feeds its new cracks into the loop, but is not re-run.'
+                          : masterOn
+                            ? 'Workflow-level loopback is on, so every eligible step loops back.'
+                            : 'Re-run this step against only newly-cracked passwords until no new cracks are found.';
 
                         return (
                           <Draggable key={job.id} draggableId={job.id} index={index} isDragDisabled={submitting}>
@@ -415,6 +485,22 @@ const JobWorkflowFormPage: React.FC = () => {
                                             variant="filled"
                                           />
                                         )}
+                                        <Tooltip title={loopbackTooltip}>
+                                          <span>
+                                            <FormControlLabel
+                                              sx={{ ml: 0.5, mr: 0 }}
+                                              control={
+                                                <Checkbox
+                                                  size="small"
+                                                  checked={loopbackChecked}
+                                                  disabled={loopbackDisabled}
+                                                  onChange={(e) => handleToggleStepLoopback(job.id, e.target.checked)}
+                                                />
+                                              }
+                                              label={<Typography variant="caption">Loopback</Typography>}
+                                            />
+                                          </span>
+                                        </Tooltip>
                                       </Box>
                                     }
                                     secondary={

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -15,6 +15,7 @@ import {
   PresetJobInput,
   PresetJobApiData,
   JobWorkflowFormDataResponse,
+  LoopbackSession,
 } from '../types/adminJobs';
 import { AgentSchedule, AgentScheduleDTO, AgentSchedulingInfo } from '../types/scheduling';
 import { AgentWithTask } from '../types/agent';
@@ -569,6 +570,13 @@ export const updateJobWorkflow = async (id: string, data: UpdateWorkflowRequest)
 
 export const deleteJobWorkflow = async (id: string): Promise<void> => {
   await api.delete(`/api/admin/job-workflows/${id}`);
+};
+
+// --- Loopback sessions (GH #64) ---
+
+export const getLoopbackSessions = async (): Promise<LoopbackSession[]> => {
+  const response = await api.get<LoopbackSession[]>('/api/loopback-sessions');
+  return response.data || [];
 };
 
 // --- Agent Management ---

--- a/frontend/src/types/adminJobs.ts
+++ b/frontend/src/types/adminJobs.ts
@@ -99,6 +99,7 @@ export interface JobWorkflow {
   updated_at: string; // ISO 8601 date string
   steps?: JobWorkflowStep[]; // Optional, included in GetByID
   has_high_priority_override?: boolean; // True if any step has high priority override
+  loopback_all_eligible?: boolean; // Master loopback toggle (GH #64)
 }
 
 // Corresponds to models.JobWorkflowStep with PresetJobName always populated
@@ -114,6 +115,21 @@ export interface JobWorkflowStep {
   preset_job_binary_name?: string; // Resolved binary version name for display
   preset_job_wordlist_ids?: string[]; // Wordlist IDs as strings
   preset_job_rule_ids?: string[]; // Rule IDs as strings
+  loopback_enabled?: boolean; // Per-step loopback toggle (GH #64)
+}
+
+// A loopback step's attack is re-run against the delta only when its mutation is
+// separable from the wordlist: straight (0) WITH rules, or a hybrid (6/7) with a mask.
+export function isLoopbackEligible(attackMode?: AttackMode, ruleIds?: string[]): boolean {
+  switch (attackMode) {
+    case AttackMode.Straight:
+      return !!ruleIds && ruleIds.length > 0;
+    case AttackMode.HybridWordlistMask:
+    case AttackMode.HybridMaskWordlist:
+      return true;
+    default:
+      return false;
+  }
 }
 
 // Corresponds to models.PresetJobBasic - for selection in forms
@@ -121,6 +137,8 @@ export interface PresetJobBasic {
   id: string; // uuid.UUID
   name: string;
   allow_high_priority_override?: boolean;
+  attack_mode?: AttackMode; // For loopback eligibility (GH #64)
+  rule_ids?: string[]; // For loopback eligibility (GH #64)
 }
 
 // Form data response for job workflow forms
@@ -133,16 +151,58 @@ export interface JobWorkflowFormData {
   name: string;
   preset_job_ids: string[]; // Array of preset job UUIDs
   orderedJobs: PresetJobBasic[]; // For UI to manage order
+  loopback_all_eligible: boolean; // Master loopback toggle (GH #64)
+  loopback_preset_job_ids: string[]; // Preset IDs with per-step loopback enabled
 }
 
 // Request type for creating/updating job workflows
 export interface CreateWorkflowRequest {
   name: string;
   preset_job_ids: string[]; // Array of preset job UUIDs
+  loopback_all_eligible: boolean; // Master loopback toggle (GH #64)
+  loopback_preset_job_ids: string[]; // Subset of preset_job_ids with per-step loopback
 }
 
 // Alias for update, same structure
 export type UpdateWorkflowRequest = CreateWorkflowRequest;
+
+// --- Loopback sessions (GH #64) ---
+export type LoopbackSessionStatus =
+  | 'waiting'
+  | 'active'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+export type LoopbackSourceType = 'workflow' | 'preset' | 'custom';
+
+export interface LoopbackSessionJob {
+  id: number;
+  session_id: string;
+  job_execution_id: string;
+  round: number;
+  role: 'original' | 'rerun';
+  is_mutatable: boolean;
+  origin_job_id?: string;
+  created_at: string;
+  job_name?: string;
+  job_status?: string;
+}
+
+export interface LoopbackSession {
+  id: string;
+  hashlist_id: number;
+  source_type: LoopbackSourceType;
+  source_workflow_id?: string;
+  name: string;
+  status: LoopbackSessionStatus;
+  current_round: number;
+  max_rounds: number;
+  error_message?: string;
+  created_by?: string;
+  created_at: string;
+  updated_at: string;
+  jobs?: LoopbackSessionJob[];
+}
 
 // Corresponds to repository.PresetJobFormData
 export interface PresetJobFormDataResponse {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,6 +112,7 @@ nav:
     - Teams: user-guide/teams.md
     - Managing Hashlists: user-guide/hashlists.md
     - Jobs & Workflows: user-guide/jobs-workflows.md
+    - Loopback: user-guide/loopback.md
     - Wordlists & Rules: user-guide/wordlists-rules.md
     - Wordlist Filtering: user-guide/wordlist-filtering.md
     - Custom Charsets & Arguments: user-guide/custom-charsets-arguments.md
@@ -197,6 +198,7 @@ nav:
       - Increment Mode: reference/architecture/increment-mode.md
       - Job Completion System: reference/architecture/job-completion-system.md
       - Job Update System: reference/architecture/job-update-system.md
+      - Loopback Sessions: reference/architecture/loopback.md
       - Notification System: reference/architecture/notification-system.md
       - Rule Splitting: reference/architecture/rule-splitting.md
       - File Hash Cache: reference/architecture/file-hash-cache.md


### PR DESCRIPTION
## Summary

Adds the **loopback** feature (resolves #64) and bundles the job-accounting and
agent-recovery fixes uncovered while building and testing it.

**Loopback** re-runs an attack's *mutating* part (rules, or a hybrid mask) against **only the
newly-cracked plaintexts** (the delta), looping until a round finds nothing new. This solves
"run the same preset multiple times in a workflow" without re-searching the whole wordlist
every pass.

## What's included

### Loopback (#64)
- **Eligibility:** straight + rules, and hybrid (`-a 6`/`-a 7`). Ineligible modes
  (wordlist-only, brute-force, combinator, association) still feed the delta pool but aren't
  re-run.
- **Delta:** distinct new plaintexts cracked by the session's own jobs, minus a per-session
  used-set (each plaintext consumed exactly once → guaranteed termination).
- **Durable controller** (`services.LoopbackService`) survives a backend restart; idle-gated
  ~7s poller.
- **Config:** workflow master toggle + per-step toggles, and a per-run "Loopback until dry"
  toggle on preset/custom jobs. Never stored on the preset definition.
- **UI:** loopback panel on the Jobs page and Dashboard (`GET /api/loopback-sessions`).
- **Safety cap:** `loopback_max_rounds` system setting (default 10).
- **Migration** `20260717120000_add_loopback` (sessions / session_jobs / session_plaintexts,
  workflow toggle columns, setting).

### Increment keyspace accounting
- `HandleWordlistUpdate` no longer clobbers increment jobs' job-level keyspace with a
  single-mask value on potfile appends.
- Progress calculator self-heals `job.base/effective_keyspace = Σ layer` each poll.
- Base-driven percentage + per-layer effective self-heal to real keyspace → removes >100%
  warnings and the frontend non-green sliver / fully-green-overflow.

### GPU device-abort recovery (agent)
- A thermal/watchdog abort or hard GPU crash (`Memory access fault by GPU node-N`) that makes
  hashcat exit 1 without reaching `progress[1]` is now **failed, not completed**, so the
  unsearched remainder re-dispatches from the recovery point. No lost work.
- Classifier: `temperature limit` / `watchdog` / `memory access fault` → transient
  GPU_WATCHDOG (re-dispatch, not quarantine). Genuine exhaustions still complete.

### Other fixes
- Potfile sync freshness (size-snapshot; MD5 verification retained).
- Agent autotune `--force` retry on kernel-autotune skip.
- Job-list FIFO sort; error-classification transient markers.

### Docs
- New `user-guide/loopback.md` and `reference/architecture/loopback.md`, registered in the
  MkDocs nav and render-validated. `loopback_max_rounds` documented in admin Job Settings;
  cross-link from Jobs & Workflows.

## Testing / verification

- ✅ Clean build of agent + backend + frontend.
- ✅ Increment keyspace fixes verified live against the DB (`job.base/effective` == Σ layer,
  even with the potfile appended mid-run).
- ✅ GPU device-abort recovery confirmed in agent + backend logs (work preserved as a
  re-dispatchable gap on a real driver crash).
- ✅ New docs render with no added MkDocs warnings.

## Notes

- The programmatic `api/v1` job-create path does not start loopback sessions (UI create path
  only) — intentional for v1.
- Custom loopback and wordlist pre-filtering are mutually exclusive in the UI.
- Pre-existing, out of scope: a broken link in `ssl-tls-provided-mode.md` and stale
  rule-splitting docs from #60.

Resolves #64.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds durable loopback re-runs for eligible rule-based and hybrid attacks, repeatedly applying mutations to newly cracked plaintexts until dry or capped. The feature includes workflow and per-job configuration, session persistence and monitoring, ephemeral delta wordlists, UI visibility, and documentation, alongside reliability fixes for execution, keyspace accounting, synchronization, potfile freshness, and job scheduling.

- **Backend**
  - Adds loopback session models, repository, service, lifecycle monitoring, delta tracking, and safety round limits.
  - Adds workflow/job configuration, eligibility handling, session listing API, and ephemeral wordlist support.
  - **Database migration:** adds workflow flags, durable loopback session tables, indexes, triggers, and `loopback_max_rounds` setting, with rollback migration.
  - **API/contract changes:** workflow create/update methods and handler constructors gain loopback parameters; new `GET /loopback-sessions` endpoint.
  - Improves keyspace progress/reconciliation, job ordering, potfile metadata consistency, partial file downloads, and transient error classification.

- **Agent**
  - Improves autotune-skip, watchdog, thermal, memory-access, and no-work detection.
  - Adds sticky kernel-force behavior, safer abort handling, keyspace exhaustion checks, and crack-work tracking to support reliable retries and re-dispatch.

- **Frontend**
  - Adds loopback controls for preset, custom, and workflow jobs with eligibility-aware UI.
  - Adds API/types for loopback sessions and dashboard/jobs monitoring panels.

- **Docs**
  - Documents loopback behavior, eligibility, configuration, lifecycle, round caps, architecture, and operational settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->