### PR TITLE
fix(ci,backend,frontend): docs deploy + dev version-stamp + main→master cleanup + interval-status bug

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - main
     paths-ignore:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/.github/workflows/deploy-docs-init.yml
+++ b/.github/workflows/deploy-docs-init.yml
@@ -74,7 +74,7 @@ jobs:
           echo "Setting version ${VERSION} as default"
           mike set-default --push "${VERSION}"
           
-          # Deploy current main branch as dev
+          # Deploy current master branch as dev
           echo "Deploying current branch as dev"
           mike deploy --push --update-aliases dev
           
@@ -114,7 +114,7 @@ jobs:
           echo "### Next Steps:" >> $GITHUB_STEP_SUMMARY
           echo "1. Visit https://zerkereod.github.io/krakenhashes/ to see the versioned documentation" >> $GITHUB_STEP_SUMMARY
           echo "2. The version selector will appear in the header" >> $GITHUB_STEP_SUMMARY
-          echo "3. Future pushes to main/master will update the 'dev' version" >> $GITHUB_STEP_SUMMARY
+          echo "3. Future pushes to master will update the 'dev' version" >> $GITHUB_STEP_SUMMARY
           echo "4. Future version tags will create new versioned documentation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Available Versions:" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,7 +3,6 @@ name: Deploy Documentation
 on:
   push:
     branches:
-      - main
       - master
     paths:
       - 'docs/**'
@@ -27,7 +26,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -121,7 +120,7 @@ jobs:
 
       - name: Build preview with mike
         run: |
-          mike deploy --no-push pr-${{ github.event.pull_request.number }}
+          mike deploy pr-${{ github.event.pull_request.number }}
           mike serve &
           sleep 5
           mkdir -p ./site

--- a/.github/workflows/validate-translations.yml
+++ b/.github/workflows/validate-translations.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - main
     paths:
       - 'frontend/public/locales/**/*.json'
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -45,7 +45,7 @@ RUN BASE_VERSION=$(jq -r .backend versions.json) && \
     else \
       VERSION="${BASE_VERSION}"; \
     fi && \
-    CGO_ENABLED=0 GOOS=linux go build -ldflags="-X main.Version=$VERSION" -o krakenhashes ./cmd/server
+    CGO_ENABLED=0 GOOS=linux go build -ldflags="-X github.com/ZerkerEOD/krakenhashes/backend/internal/version.Version=$VERSION" -o krakenhashes ./cmd/server
 
 # Final stage - Debian without PostgreSQL
 FROM debian:12-slim

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -127,7 +127,7 @@ func main() {
 		debug.Error("Failed to load version information: %v", err)
 		os.Exit(1)
 	}
-	debug.Info("KrakenHashes Backend v%s starting up", version.Version)
+	debug.Info("KrakenHashes Backend v%s starting up", version.BackendVersion())
 	debug.Info("Component versions - Frontend: %s, Agent: %s, API: %s, Database: %s",
 		version.Versions.Frontend,
 		version.Versions.Agent,

--- a/backend/internal/services/diagnostic/diagnostic_service.go
+++ b/backend/internal/services/diagnostic/diagnostic_service.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	wshandler "github.com/ZerkerEOD/krakenhashes/backend/internal/handlers/websocket"
+	"github.com/ZerkerEOD/krakenhashes/backend/internal/version"
 	"github.com/ZerkerEOD/krakenhashes/backend/pkg/debug"
 	"github.com/google/uuid"
 )
@@ -150,6 +151,10 @@ func (s *DiagnosticService) collectSystemInfo(ctx context.Context) (map[string]i
 	info := make(map[string]interface{})
 
 	// Runtime info
+	// backend_version is the build-stamped version: "<backend>-<commit>-dev" on dev
+	// builds, bare "<backend>" on release — so a diagnostic dump identifies the exact
+	// deployed commit (falls back to versions.json when built without the ldflag).
+	info["backend_version"] = version.BackendVersion()
 	info["go_version"] = runtime.Version()
 	info["go_os"] = runtime.GOOS
 	info["go_arch"] = runtime.GOARCH

--- a/backend/internal/services/hashlist_completion_service.go
+++ b/backend/internal/services/hashlist_completion_service.go
@@ -239,22 +239,29 @@ func (s *HashlistCompletionService) stopJobTasks(ctx context.Context, jobID uuid
 		}
 	}
 
-	// Scheduler-v2 cascade: also mark every non-terminal interval for
-	// this job's units as 'cancelled'. Without this, the per-task bar's
-	// "pending" gray space (= undispatched gaps) persists visually even
-	// after the hashlist is fully cracked, because the bar's universe is
-	// the full effective keyspace. Cancelling open intervals doesn't
-	// affect the gap query (it already ignores 'failed'/'cancelled') —
-	// it's purely a UI honesty fix.
+	// Scheduler-v2 cascade: also mark every still-open interval for this
+	// job's units terminal. Without this, the per-task bar's "pending" gray
+	// space (= dispatched-but-not-finished chunks) persists visually even
+	// after the hashlist is fully cracked, because the bar's universe is the
+	// full effective keyspace. We use 'completed' (NOT 'cancelled'): the
+	// interval CHECK constraint (valid_interval_status, migration 000147)
+	// permits only assigned/running/completed/failed, so an earlier
+	// 'cancelled' write always failed the constraint and this cascade was a
+	// silent no-op. 'completed' is coverage-neutral here — the gap/coverage
+	// gates already count any interval with status <> 'failed' as covered
+	// (keyspace_interval_repository.go, job_progress_calculation_service.go) —
+	// so promoting assigned/running → completed changes no coverage total; it
+	// only gives the bar a terminal state. Purely a UI-honesty fix on an
+	// all-cracked completion.
 	if _, err := s.db.ExecContext(ctx, `
 		UPDATE job_keyspace_intervals jki
-		SET status = 'cancelled'
+		SET status = 'completed'
 		FROM scheduling_units su
 		WHERE jki.scheduling_unit_id = su.id
 		  AND su.parent_job_id = $1
 		  AND jki.status IN ('assigned', 'running')
 	`, jobID); err != nil {
-		debug.Warning("Failed to cascade intervals cancelled for job %s: %v", jobID, err)
+		debug.Warning("Failed to cascade open intervals to completed for job %s: %v", jobID, err)
 	}
 
 	if stoppedCount > 0 {

--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -50,7 +50,22 @@ func LoadVersions(path string) error {
 	return nil
 }
 
-// GetVersionInfo returns all version information
+// BackendVersion returns the build-stamped backend version for display/diagnostics.
+// The linker sets Version via -ldflags at build time (see Dockerfile.prod): on a dev
+// build it is "<backend>-<commit>-dev", on a release-tagged build it is the bare
+// "<backend>". When built without the ldflag (e.g. a plain local `go build`), Version
+// is empty and we fall back to the backend value from versions.json so the string is
+// never blank.
+func BackendVersion() string {
+	if Version != "" {
+		return Version
+	}
+	return Versions.Backend
+}
+
+// GetVersionInfo returns all version information. "build" carries the build-stamped
+// backend version (with the commit + -dev suffix on dev builds); the component keys
+// remain the bare semver values from versions.json for any consumer that parses them.
 func GetVersionInfo() map[string]string {
 	debug.Debug("Retrieving version information")
 	return map[string]string{
@@ -60,5 +75,6 @@ func GetVersionInfo() map[string]string {
 		"agent":    Versions.Agent,
 		"api":      Versions.API,
 		"database": Versions.Database,
+		"build":    BackendVersion(),
 	}
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -139,7 +139,8 @@
       "frontend": "Frontend",
       "agent": "Agent Version",
       "api": "API Version",
-      "database": "Database"
+      "database": "Database",
+      "build": "Build"
     },
     "projectInfo": {
       "title": "Project Information",

--- a/frontend/src/api/version.ts
+++ b/frontend/src/api/version.ts
@@ -7,6 +7,9 @@ export interface VersionInfo {
     agent: string;
     api: string;
     database: string;
+    // build is the backend's build-stamped version: "<backend>-<commit>-dev" on dev
+    // builds, bare "<backend>" on release. Present when the backend exposes it.
+    build?: string;
 }
 
 export const getVersionInfo = async (): Promise<VersionInfo> => {

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -35,7 +35,10 @@ const Footer: React.FC<FooterProps> = ({ drawerOpen }) => {
     const fetchVersion = async () => {
       try {
         const versionInfo = await getVersionInfo();
-        setVersion(versionInfo.release || versionInfo.backend || '');
+        // On dev builds the backend stamps build as "<backend>-<commit>-dev"; show it
+        // so the running commit is identifiable. Release builds keep the bare version.
+        const isDevBuild = !!versionInfo.build && versionInfo.build.includes('-dev');
+        setVersion(isDevBuild ? versionInfo.build! : (versionInfo.release || versionInfo.backend || ''));
       } catch (error) {
         console.error('Failed to fetch version:', error);
         setVersion('');

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -69,6 +69,13 @@ const About: React.FC = () => {
 
                     <Typography><strong>{t('about.versionInfo.database') as string}:</strong></Typography>
                     <Typography>{versions.database}</Typography>
+
+                    {versions.build && versions.build.includes('-dev') && (
+                        <>
+                            <Typography><strong>{t('about.versionInfo.build') as string}:</strong></Typography>
+                            <Typography sx={{ fontFamily: 'monospace' }}>{versions.build}</Typography>
+                        </>
+                    )}
                 </Box>
             </Paper>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_author: ZerkerEOD
 
 repo_name: ZerkerEOD/krakenhashes
 repo_url: https://github.com/ZerkerEOD/krakenhashes
-edit_uri: edit/main/docs/
+edit_uri: edit/master/docs/
 
 theme:
   name: material


### PR DESCRIPTION
## Summary

Quick-wins pass surfaced while diagnosing a reporting user's environment (the chunk-sizing /
slow-hash speed root cause is a separate, design-first PR). Independent of #68 — and merging the
`deploy-docs.yml` fix here also makes any open PR's docs-preview check pass on re-run.

## CI / docs
- **`deploy-docs.yml`:** drop the invalid `mike deploy --no-push` flag. `mike` doesn't push
  unless given `--push`, so "no push" is already the default; the flag was failing the docs
  preview job with `unrecognized arguments: --no-push`.
- **Remove dead `main` triggers/guards** (master is canonical; there is no `main` branch) from
  `deploy-docs.yml`, `build-dev.yml`, `validate-translations.yml`, `deploy-docs-init.yml`.
- **`mkdocs.yml`:** `edit_uri` `edit/main` → `edit/master` (the "Edit this page" links pointed at
  a non-existent branch).

## Dev version stamp — identify the deployed commit
Motivation: while diagnosing the reporting user I couldn't tell which commit their backend was
running, because the version stamp never actually worked.
- `Dockerfile.prod` stamped the commit via `-X main.Version`, but the code's build var is
  `internal/version.Version` — so the ldflag was a **no-op** (the startup log even printed a blank
  version). Point the ldflag at the real variable.
- New `version.BackendVersion()`: `<backend>-<commit>-dev` on dev builds, bare `<backend>` on
  release, falling back to `versions.json` when built without the ldflag (local `go build`).
- Surfaced in: the startup log, `/api/version` (new `build` field), the **diagnostic export**
  (`system_info.backend_version`), the frontend Footer (dev builds only), and the About page.
- Release-tagged builds keep the bare version (per the requirement); no consumer parses `build`
  as semver, and the component keys stay unchanged.

## Latent bug
- `hashlist_completion_service`: the all-cracked cascade set open intervals to `'cancelled'`,
  which violates the `valid_interval_status` CHECK (migration 000147 allows only
  `assigned/running/completed/failed`) — so it always errored and was swallowed as a warning (a
  silent no-op). Use `'completed'`: coverage-neutral (gap/coverage gates already filter
  `status <> 'failed'`), giving the per-task bar a real terminal state after an all-cracked
  completion.

## Testing / verification
- Docs: validated locally with a strict MkDocs build previously; the `mike deploy pr-<n>` step is
  now correct.
- Version stamp / interval fix: **build pending** (assistant does not build). After a dev build:
  `/api/version` and the startup log show `<backend>-<commit>-dev`; a diagnostic dump's
  `system_info.backend_version` carries the commit; a release build shows the bare version. Fully
  cracking a hashlist should no longer log "Failed to cascade … cancelled", and open intervals
  become `completed` with the job/tasks still completing.

## Not in scope
- The chunk-sizing / slow-hash (`-S`) GPU-underutilization fix — separate design-first PR, pending
  an empirical `-S` test on real GPUs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates CI and documentation deployment to use `master`, fixes production version stamping, and adds development build version visibility across the backend and frontend. Hashlist completion now marks active intervals as `completed` to satisfy database constraints.

- **Backend:** Added build-aware version reporting with release fallback; exposed it in startup logs, `/api/version`, and diagnostics. Updated fully-cracked hashlist interval handling from `cancelled` to `completed`.
- **Agent:** No agent behavior changes; development CI now targets `master`.
- **Frontend:** Added optional build version API support and displays development build identifiers in the footer and About page.
- **Docs/CI:** Removed invalid MkDocs deployment usage, restricted workflows to `master`, and updated documentation edit links.
- **API/contract:** Version responses now optionally include a `build` field; no breaking changes or database migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->