### PR TITLE
fix(ci): bump Docker golang builder image to 1.25 to match go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY frontend/ ./
 RUN npm run build
 
 # Build stage for agents (all platforms)
-FROM golang:1.24-alpine AS agent-builder
+FROM golang:1.25-alpine AS agent-builder
 RUN apk add --no-cache make jq
 
 # Set up parent directory and copy versions.json first
@@ -29,7 +29,7 @@ COPY agent/ ./
 RUN make clean && make build-all
 
 # Build stage for backend
-FROM golang:1.24-alpine AS backend-builder
+FROM golang:1.25-alpine AS backend-builder
 WORKDIR /app/backend
 # Install jq for version extraction
 RUN apk add --no-cache jq

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -20,7 +20,7 @@ COPY frontend/ ./
 RUN npm run build
 
 # Build stage for backend
-FROM golang:1.24-alpine AS backend-builder
+FROM golang:1.25-alpine AS backend-builder
 ARG COMMIT_SHA
 ARG BUILD_TYPE
 WORKDIR /app/backend


### PR DESCRIPTION
## Summary

Fixes the post-merge Docker build failure in the backend-builder stage:

```
go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)
```

### Root cause

PR #71 ran `go mod tidy`, which lifted the backend `go.mod` `go` directive to **1.25.0** (the newer `golang.org/x/*` deps require it). The Docker builder stages were still `golang:1.24-alpine` with `GOTOOLCHAIN=local`, so they refused to build a module requiring Go ≥ 1.25.

### Fix

Bump the Go builder images to match the `go.mod` directive:

- `Dockerfile` — `agent-builder` + `backend-builder` → `golang:1.25-alpine`
- `Dockerfile.prod` — `backend-builder` → `golang:1.25-alpine`

### Why no CI workflow changes

The `actions/setup-go@1.24` steps in `release.yml` / `build-dev.yml` / etc. compile only the **agent** (`agent/go.mod` is `go 1.23.1`, satisfied by 1.24). The backend is compiled exclusively **inside Docker** via `Dockerfile.prod`, so bumping the builder image is sufficient. There is no standalone backend test/vet CI step.

https://claude.ai/code/session_01Chv4uXmJ5Gc9Voej3ug3v4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates Docker Go builder images to Go 1.25 to satisfy the backend’s `go.mod` requirement and prevent Docker build failures.

- **Backend:** Updated builder images in `Dockerfile` and `Dockerfile.prod`.
- **Agent:** Updated the agent builder image in `Dockerfile`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->