### PR TITLE
fix(backend,agent): sync client-specific wordlists & potfiles at dispatch (#67)

### DIFF
--- a/agent/internal/jobs/hashcat_executor.go
+++ b/agent/internal/jobs/hashcat_executor.go
@@ -778,24 +778,30 @@ func (e *HashcatExecutor) selectHybridWordlist(assignment *JobTaskAssignment) st
 		return filepath.Join(e.dataDirectory, assignment.WordlistPaths[0])
 	}
 
-	// Fall back to a client-specific wordlist (existence-guarded like mode 0).
+	// Fall back to a client-specific wordlist, then the client potfile. These
+	// paths come straight off the task assignment, so validate each with
+	// resolveDataPath (rejects absolute paths and "../" traversal) before
+	// pointing hashcat at it — existence-guarded like the mode-0 handling.
 	if len(assignment.ClientWordlistPaths) > 0 {
-		fullPath := filepath.Join(e.dataDirectory, assignment.ClientWordlistPaths[0])
-		if _, err := os.Stat(fullPath); err == nil {
+		if fullPath, err := resolveDataPath(e.dataDirectory, assignment.ClientWordlistPaths[0]); err != nil {
+			debug.Warning("Refusing non-local client wordlist path %q: %v", assignment.ClientWordlistPaths[0], err)
+		} else if _, statErr := os.Stat(fullPath); statErr == nil {
 			debug.Info("Using client wordlist for hybrid attack: %s", fullPath)
 			return fullPath
+		} else {
+			debug.Warning("Client wordlist not found, skipping: %s", fullPath)
 		}
-		debug.Warning("Client wordlist not found, skipping: %s", fullPath)
 	}
 
-	// Finally fall back to the client potfile (a wordlist of previously cracked passwords).
 	if assignment.ClientPotfilePath != "" {
-		fullPath := filepath.Join(e.dataDirectory, assignment.ClientPotfilePath)
-		if _, err := os.Stat(fullPath); err == nil {
+		if fullPath, err := resolveDataPath(e.dataDirectory, assignment.ClientPotfilePath); err != nil {
+			debug.Warning("Refusing non-local client potfile path %q: %v", assignment.ClientPotfilePath, err)
+		} else if _, statErr := os.Stat(fullPath); statErr == nil {
 			debug.Info("Using client potfile as wordlist for hybrid attack: %s", fullPath)
 			return fullPath
+		} else {
+			debug.Warning("Client potfile not found, skipping: %s", fullPath)
 		}
-		debug.Warning("Client potfile not found, skipping: %s", fullPath)
 	}
 
 	return ""
@@ -1017,11 +1023,14 @@ func (e *HashcatExecutor) buildHashcatCommandWithOptions(assignment *JobTaskAssi
 			args = append(args, fullPath)
 		}
 
-		// Add client potfile as a wordlist if specified
-		// Client potfile is a wordlist of previously cracked passwords for this client
+		// Add client potfile as a wordlist if specified (a wordlist of previously
+		// cracked passwords for this client). The path comes off the task
+		// assignment, so validate it with resolveDataPath (rejects absolute
+		// paths / "../" traversal) before use.
 		if assignment.ClientPotfilePath != "" {
-			fullPath := filepath.Join(e.dataDirectory, assignment.ClientPotfilePath)
-			if _, err := os.Stat(fullPath); err == nil {
+			if fullPath, err := resolveDataPath(e.dataDirectory, assignment.ClientPotfilePath); err != nil {
+				debug.Warning("Refusing non-local client potfile path %q: %v", assignment.ClientPotfilePath, err)
+			} else if _, statErr := os.Stat(fullPath); statErr == nil {
 				debug.Info("Adding client potfile as wordlist: %s", fullPath)
 				args = append(args, fullPath)
 			} else {
@@ -1029,12 +1038,16 @@ func (e *HashcatExecutor) buildHashcatCommandWithOptions(assignment *JobTaskAssi
 			}
 		}
 
-		// Add client-specific wordlists if specified
+		// Add client-specific wordlists if specified (same path validation).
 		if len(assignment.ClientWordlistPaths) > 0 {
 			debug.Info("Adding client wordlists to hashcat command: %v", assignment.ClientWordlistPaths)
 			for _, wordlistPath := range assignment.ClientWordlistPaths {
-				fullPath := filepath.Join(e.dataDirectory, wordlistPath)
-				if _, err := os.Stat(fullPath); err == nil {
+				fullPath, err := resolveDataPath(e.dataDirectory, wordlistPath)
+				if err != nil {
+					debug.Warning("Refusing non-local client wordlist path %q: %v", wordlistPath, err)
+					continue
+				}
+				if _, statErr := os.Stat(fullPath); statErr == nil {
 					debug.Info("Adding client wordlist: %s", fullPath)
 					args = append(args, fullPath)
 				} else {

--- a/agent/internal/jobs/hashcat_executor.go
+++ b/agent/internal/jobs/hashcat_executor.go
@@ -766,6 +766,41 @@ func hasSlowCandidatesFlag(args []string) bool {
 	return false
 }
 
+// selectHybridWordlist returns the full local path of the single wordlist for a
+// hybrid attack, preferring WordlistPaths[0] and falling back to a client-specific
+// wordlist (then the client potfile) when the generic list is empty — mirroring the
+// mode-0 handling so hybrid jobs that use a client wordlist aren't silently dropped.
+// Returns "" if none is available or the chosen client file is missing on disk.
+func (e *HashcatExecutor) selectHybridWordlist(assignment *JobTaskAssignment) string {
+	// Prefer the generic wordlist list (existing behavior — no os.Stat so we
+	// don't change current semantics for global-wordlist hybrid jobs).
+	if len(assignment.WordlistPaths) > 0 {
+		return filepath.Join(e.dataDirectory, assignment.WordlistPaths[0])
+	}
+
+	// Fall back to a client-specific wordlist (existence-guarded like mode 0).
+	if len(assignment.ClientWordlistPaths) > 0 {
+		fullPath := filepath.Join(e.dataDirectory, assignment.ClientWordlistPaths[0])
+		if _, err := os.Stat(fullPath); err == nil {
+			debug.Info("Using client wordlist for hybrid attack: %s", fullPath)
+			return fullPath
+		}
+		debug.Warning("Client wordlist not found, skipping: %s", fullPath)
+	}
+
+	// Finally fall back to the client potfile (a wordlist of previously cracked passwords).
+	if assignment.ClientPotfilePath != "" {
+		fullPath := filepath.Join(e.dataDirectory, assignment.ClientPotfilePath)
+		if _, err := os.Stat(fullPath); err == nil {
+			debug.Info("Using client potfile as wordlist for hybrid attack: %s", fullPath)
+			return fullPath
+		}
+		debug.Warning("Client potfile not found, skipping: %s", fullPath)
+	}
+
+	return ""
+}
+
 // buildHashcatCommand builds the hashcat command line arguments
 func (e *HashcatExecutor) buildHashcatCommand(assignment *JobTaskAssignment) (*exec.Cmd, string, string, string, float64, error) {
 	return e.buildHashcatCommandWithOptions(assignment, false)
@@ -1029,14 +1064,18 @@ func (e *HashcatExecutor) buildHashcatCommandWithOptions(assignment *JobTaskAssi
 		}
 
 	case int(AttackModeHybridWordlistMask): // Hybrid Wordlist + Mask
-		if len(assignment.WordlistPaths) > 0 && assignment.Mask != "" {
-			wordlistPath := filepath.Join(e.dataDirectory, assignment.WordlistPaths[0])
+		// Prefer the generic wordlist, falling back to client wordlist/potfile
+		// so a client wordlist routed via ClientWordlistPaths isn't dropped.
+		wordlistPath := e.selectHybridWordlist(assignment)
+		if wordlistPath != "" && assignment.Mask != "" {
 			args = append(args, wordlistPath, assignment.Mask)
 		}
 
 	case int(AttackModeHybridMaskWordlist): // Hybrid Mask + Wordlist
-		if assignment.Mask != "" && len(assignment.WordlistPaths) > 0 {
-			wordlistPath := filepath.Join(e.dataDirectory, assignment.WordlistPaths[0])
+		// Prefer the generic wordlist, falling back to client wordlist/potfile
+		// so a client wordlist routed via ClientWordlistPaths isn't dropped.
+		wordlistPath := e.selectHybridWordlist(assignment)
+		if assignment.Mask != "" && wordlistPath != "" {
 			args = append(args, assignment.Mask, wordlistPath)
 		}
 

--- a/agent/internal/jobs/jobs.go
+++ b/agent/internal/jobs/jobs.go
@@ -601,6 +601,16 @@ func (jm *JobManager) ensureWordlists(ctx context.Context, assignment *JobTaskAs
 	}
 
 	for _, wordlistPath := range assignment.WordlistPaths {
+		// Client wordlists/potfiles (wordlists/clients/{clientID}/...) are delivered by
+		// ensureClientWordlists / ensureClientPotfile via the dedicated authenticated
+		// endpoints (+ post-task cleanup). They appear in WordlistPaths only for
+		// combinator (-a 1), where they must stay positional for ordering. Skip them
+		// here so we don't hit the generic file endpoint, which 404s on the
+		// clients/{uuid}/ subpath.
+		if strings.HasPrefix(wordlistPath, "wordlists/clients/") {
+			continue
+		}
+
 		localPath, err := resolveDataPath(jm.config.DataDirectory, wordlistPath)
 		if err != nil {
 			debug.Error("Rejecting wordlist path: %v", err)

--- a/backend/internal/handlers/jobs/user_jobs.go
+++ b/backend/internal/handlers/jobs/user_jobs.go
@@ -410,52 +410,65 @@ type JobNameConfig struct {
 	AssociationWordlistName string // For association attack (mode 9)
 }
 
-// resolveWordlistNames converts wordlist IDs to their names
+// resolveWordlistName resolves a single wordlist ID — a global integer ID, a
+// "client:UUID" client wordlist, or a "potfile:ID" client potfile — to its
+// display name. Returns ok=false when the ID can't be resolved (bad format,
+// missing row, or an unconfigured repo) so callers can choose whether to skip
+// it or substitute a placeholder.
+func (h *UserJobsHandler) resolveWordlistName(ctx context.Context, idStr string) (string, bool) {
+	// Client-specific wordlist: "client:UUID"
+	if strings.HasPrefix(idStr, "client:") {
+		if h.clientWordlistManager == nil {
+			return "", false
+		}
+		clientWordlistID, err := uuid.Parse(strings.TrimPrefix(idStr, "client:"))
+		if err != nil {
+			return "", false
+		}
+		wl, err := h.clientWordlistManager.Get(ctx, clientWordlistID)
+		if err != nil || wl == nil {
+			return "", false
+		}
+		return wl.FileName, true
+	}
+
+	// Client potfile: "potfile:ID"
+	if strings.HasPrefix(idStr, "potfile:") {
+		if h.clientPotfileRepo == nil {
+			return "", false
+		}
+		potfileID, err := strconv.Atoi(strings.TrimPrefix(idStr, "potfile:"))
+		if err != nil {
+			return "", false
+		}
+		pf, err := h.clientPotfileRepo.GetByID(ctx, potfileID)
+		if err != nil || pf == nil {
+			return "", false
+		}
+		return "Client Potfile", true
+	}
+
+	// Global wordlist: numeric ID
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		return "", false
+	}
+	wl, err := h.wordlistStore.GetWordlist(ctx, id)
+	if err != nil || wl == nil {
+		return "", false
+	}
+	return wl.Name, true
+}
+
+// resolveWordlistNames converts wordlist IDs to their names, skipping any that
+// can't be resolved (used for building job names, where an "Unknown" placeholder
+// would be noise).
 func (h *UserJobsHandler) resolveWordlistNames(ctx context.Context, wordlistIDs []string) []string {
 	names := make([]string, 0, len(wordlistIDs))
 	for _, idStr := range wordlistIDs {
-		// Check for client-specific wordlist prefix "client:UUID"
-		if strings.HasPrefix(idStr, "client:") {
-			uuidStr := strings.TrimPrefix(idStr, "client:")
-			clientWordlistID, err := uuid.Parse(uuidStr)
-			if err != nil {
-				continue
-			}
-			if h.clientWordlistManager != nil {
-				wl, err := h.clientWordlistManager.Get(ctx, clientWordlistID)
-				if err == nil && wl != nil {
-					names = append(names, wl.FileName)
-				}
-			}
-			continue
+		if name, ok := h.resolveWordlistName(ctx, idStr); ok {
+			names = append(names, name)
 		}
-
-		// Check for client potfile prefix "potfile:ID"
-		if strings.HasPrefix(idStr, "potfile:") {
-			potfileIDStr := strings.TrimPrefix(idStr, "potfile:")
-			potfileID, err := strconv.Atoi(potfileIDStr)
-			if err != nil {
-				continue
-			}
-			if h.clientPotfileRepo != nil {
-				pf, err := h.clientPotfileRepo.GetByID(ctx, potfileID)
-				if err == nil && pf != nil {
-					names = append(names, "Client Potfile")
-				}
-			}
-			continue
-		}
-
-		// Global wordlist - numeric ID
-		id, err := strconv.Atoi(idStr)
-		if err != nil {
-			continue
-		}
-		wl, err := h.wordlistStore.GetWordlist(ctx, id)
-		if err != nil || wl == nil {
-			continue
-		}
-		names = append(names, wl.Name)
 	}
 	return names
 }
@@ -1305,22 +1318,17 @@ func (h *UserJobsHandler) GetJobDetail(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Resolve wordlist IDs to names
+	// Resolve wordlist IDs to names. Handles global integer IDs as well as
+	// "client:UUID" and "potfile:ID" IDs. Keeps one entry per ID (with an
+	// "Unknown" placeholder for genuinely-unresolvable IDs) so the frontend's
+	// positional combinator display (wordlist_names[0]/[1]) stays aligned.
 	wordlistNames := make([]string, 0, len(job.WordlistIDs))
 	for _, idStr := range job.WordlistIDs {
-		id, err := strconv.Atoi(idStr)
-		if err != nil {
-			debug.Warning("Invalid wordlist ID %s for job %s: %v", idStr, jobID, err)
+		if name, ok := h.resolveWordlistName(ctx, idStr); ok {
+			wordlistNames = append(wordlistNames, name)
+		} else {
 			wordlistNames = append(wordlistNames, fmt.Sprintf("Unknown (ID: %s)", idStr))
-			continue
 		}
-		wl, err := h.wordlistStore.GetWordlist(ctx, id)
-		if err != nil || wl == nil {
-			debug.Warning("Failed to get wordlist %d for job %s: %v", id, jobID, err)
-			wordlistNames = append(wordlistNames, fmt.Sprintf("Unknown (ID: %d)", id))
-			continue
-		}
-		wordlistNames = append(wordlistNames, wl.Name)
 	}
 
 	// Resolve rule IDs to names

--- a/backend/internal/services/scheduler/client_lists_test.go
+++ b/backend/internal/services/scheduler/client_lists_test.go
@@ -1,0 +1,102 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestClassifyClientWordlistPath(t *testing.T) {
+	clientUUID := "550e8400-e29b-41d4-a716-446655440000"
+
+	tests := []struct {
+		name         string
+		path         string
+		wantIsClient bool
+		wantClientID string // expected UUID string when wantIsClient; ignored otherwise
+		wantFilename string
+	}{
+		{
+			name:         "client wordlist",
+			path:         "wordlists/clients/" + clientUUID + "/rockyou.txt",
+			wantIsClient: true,
+			wantClientID: clientUUID,
+			wantFilename: "rockyou.txt",
+		},
+		{
+			name:         "client potfile",
+			path:         "wordlists/clients/" + clientUUID + "/potfile.txt",
+			wantIsClient: true,
+			wantClientID: clientUUID,
+			wantFilename: "potfile.txt",
+		},
+		{
+			name:         "global wordlist",
+			path:         "wordlists/general/rockyou.txt",
+			wantIsClient: false,
+		},
+		{
+			name:         "custom wordlist",
+			path:         "wordlists/custom/x.txt",
+			wantIsClient: false,
+		},
+		{
+			name:         "association wordlist",
+			path:         "wordlists/association/5_x.txt",
+			wantIsClient: false,
+		},
+		{
+			name:         "malformed uuid",
+			path:         "wordlists/clients/not-a-uuid/x.txt",
+			wantIsClient: false,
+		},
+		{
+			name:         "wrong prefix",
+			path:         "rules/clients/" + clientUUID + "/x.txt",
+			wantIsClient: false,
+		},
+		{
+			name:         "too few segments",
+			path:         "wordlists/clients/" + clientUUID,
+			wantIsClient: false,
+		},
+		{
+			name:         "empty filename",
+			path:         "wordlists/clients/" + clientUUID + "/",
+			wantIsClient: false,
+		},
+		{
+			name:         "empty path",
+			path:         "",
+			wantIsClient: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isClient, clientID, filename := classifyClientWordlistPath(tt.path)
+
+			if isClient != tt.wantIsClient {
+				t.Fatalf("isClient = %v, want %v", isClient, tt.wantIsClient)
+			}
+
+			if !tt.wantIsClient {
+				// Non-client paths must return the zero values.
+				if clientID != uuid.Nil {
+					t.Errorf("clientID = %s, want uuid.Nil", clientID)
+				}
+				if filename != "" {
+					t.Errorf("filename = %q, want empty", filename)
+				}
+				return
+			}
+
+			if clientID.String() != tt.wantClientID {
+				t.Errorf("clientID = %s, want %s", clientID, tt.wantClientID)
+			}
+			if filename != tt.wantFilename {
+				t.Errorf("filename = %q, want %q", filename, tt.wantFilename)
+			}
+		})
+	}
+}

--- a/backend/internal/services/scheduler/cycle.go
+++ b/backend/internal/services/scheduler/cycle.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -1111,19 +1112,13 @@ func (c *Cycle) sendAssignment(ctx context.Context, dt DispatchedTask, unit *mod
 		payload.ClientID = hashlistClientID.UUID.String()
 	}
 
-	// TODO (separate v2 gap): ClientPotfilePath is intentionally NOT
-	// set here. The legacy dispatcher set it only when the user
-	// referenced a "potfile:ID" prefix in their job's wordlist list,
-	// and the resolution happened at dispatch time. The v2 unit
-	// creation (populateSchedulingUnits in job_execution_v2.go) does
-	// NOT yet handle "potfile:ID" or "client:UUID" wordlist prefixes,
-	// so by the time we get here the prefix has either been stripped
-	// or stored as a raw ref the agent can't resolve. Fixing this is
-	// scoped to job_execution_v2.go, not this dispatch site. Until
-	// then, jobs that reference a client potfile as a wordlist will
-	// silently degrade (the agent will fail to find the file).
-	// The crack-save path is unaffected — hashes.client_id routing
-	// happens server-side in processCrackedHashes regardless.
+	// Client wordlists and the client potfile arrive flattened into the
+	// generic payload.WordlistPaths as "wordlists/clients/{clientID}/{file}"
+	// relative paths. The agent can't download those from the generic
+	// wordlist endpoint — it needs the dedicated UUID/client-keyed fields
+	// (ClientWordlistPaths/ClientWordlistIDs/ClientPotfilePath). routeClientLists
+	// (called just before attachFileMD5s below) pulls those refs out of
+	// WordlistPaths and into the dedicated fields.
 
 	// Agent-level fields: extra_parameters + enabled device list.
 	// Matches the legacy lookup at job_websocket_integration.go:561
@@ -1162,6 +1157,15 @@ func (c *Cycle) sendAssignment(ctx context.Context, dt DispatchedTask, unit *mod
 			payload.BinaryPath = fmt.Sprintf("binaries/%d", binaryID)
 		}
 	}
+
+	// Route client-specific wordlists and the client potfile out of the
+	// generic WordlistPaths and into their dedicated payload fields
+	// (ClientWordlistPaths/ClientWordlistIDs/ClientPotfilePath) so the agent
+	// can download them from the client-keyed endpoints. This MUST run before
+	// attachFileMD5s so the MD5 lookup below only sees the remaining global
+	// wordlist paths (client files live in a separate table with their own
+	// verification/serving path).
+	c.routeClientLists(ctx, payload)
 
 	// Attach the current on-server MD5 for every wordlist/rule/binary this
 	// task references so the agent can verify each file and re-download any
@@ -1244,6 +1248,155 @@ func (c *Cycle) attachFileMD5s(ctx context.Context, payload *wsservice.TaskAssig
 			}
 		}
 	}
+}
+
+// classifyClientWordlistPath reports whether a wire path refers to a
+// client-specific file and, if so, extracts the owning client UUID and the
+// filename. Client refs have the exact shape
+// "wordlists/clients/{clientID}/{filename}" (4 slash-separated segments). Any
+// other shape — global ("wordlists/general/x.txt"), custom
+// ("wordlists/custom/x.txt"), association ("wordlists/association/5_x.txt"), a
+// malformed UUID, the wrong prefix, or a missing/empty filename — returns
+// (false, uuid.Nil, "").
+//
+// Pure and package-level so it's unit-testable without a DB.
+func classifyClientWordlistPath(p string) (isClient bool, clientID uuid.UUID, filename string) {
+	segments := strings.Split(p, "/")
+	if len(segments) != 4 {
+		return false, uuid.Nil, ""
+	}
+	if segments[0] != "wordlists" || segments[1] != "clients" || segments[3] == "" {
+		return false, uuid.Nil, ""
+	}
+	id, err := uuid.Parse(segments[2])
+	if err != nil {
+		return false, uuid.Nil, ""
+	}
+	return true, id, segments[3]
+}
+
+// routeClientLists reclassifies client-specific wordlists and the client
+// potfile out of the generic payload.WordlistPaths and into their dedicated
+// payload fields so the agent can download them from the client-keyed
+// endpoints (the generic wordlist endpoint can't serve them). Client refs are
+// flattened into WordlistPaths as "wordlists/clients/{clientID}/{filename}"
+// during unit resolution; here we pull them back out:
+//
+//   - "…/potfile.txt"    → ClientPotfilePath (agent downloads it by ClientID,
+//     which is already set from hashlists.client_id).
+//   - any other filename → ClientWordlistPaths + ClientWordlistIDs, with the
+//     wordlist UUID recovered from client_wordlists by matching
+//     filepath.Base(file_path) (the on-disk/wire name is sanitized, whereas
+//     file_name is the raw original — so we must NOT match on file_name).
+//
+// The two client-wordlist slices are appended in lockstep so index i of
+// ClientWordlistPaths corresponds to index i of ClientWordlistIDs — the agent
+// relies on this pairing to download each file by its ID.
+//
+// Combinator exception (-a 1): for single-wordlist modes (0/6/7) a routed
+// client ref is REMOVED from WordlistPaths entirely — the agent only needs it
+// in the dedicated fields. But combinator uses exactly two wordlists read
+// positionally from WordlistPaths[0] and WordlistPaths[1], so pulling a client
+// ref out would lose both the count and the left/right order. When
+// payload.AttackMode == AttackModeCombinator we therefore ALSO keep the ref in
+// remaining (at its original position) while still populating the dedicated
+// fields — the agent downloads/cleans it via the client endpoint and skips it
+// in ensureWordlists, so no double-download results. Ordering is preserved
+// because we iterate WordlistPaths in order and append to remaining in order.
+//
+// Best-effort by design (mirrors attachFileMD5s): a client wordlist whose UUID
+// can't be recovered — or any query/scan error — is logged and left in the
+// remaining WordlistPaths rather than dropped, and nothing here ever returns an
+// error or panics. That degrades gracefully (the agent's existence check kicks
+// in) instead of blocking dispatch.
+func (c *Cycle) routeClientLists(ctx context.Context, payload *wsservice.TaskAssignmentPayload) {
+	if len(payload.WordlistPaths) == 0 {
+		return
+	}
+
+	remaining := make([]string, 0, len(payload.WordlistPaths))
+	for _, p := range payload.WordlistPaths {
+		isClient, clientID, filename := classifyClientWordlistPath(p)
+		if !isClient {
+			remaining = append(remaining, p)
+			continue
+		}
+
+		// The client potfile is served by ClientID (already set from
+		// hashlists.client_id), not by a wordlist UUID, so it never needs a
+		// client_wordlists lookup.
+		if filename == "potfile.txt" {
+			if payload.ClientID != "" && clientID.String() != payload.ClientID {
+				debug.Warning("scheduler-v2: client potfile ref %q client %s != hashlist client %s; using ref anyway",
+					p, clientID, payload.ClientID)
+			}
+			payload.ClientPotfilePath = p
+			// Combinator (-a 1) reads two wordlists positionally, so the ref
+			// must also stay in WordlistPaths at its slot; other modes don't.
+			if payload.AttackMode == AttackModeCombinator {
+				remaining = append(remaining, p)
+				debug.Info("scheduler-v2: routed client potfile %q to ClientPotfilePath (kept in WordlistPaths for combinator)", p)
+			} else {
+				debug.Info("scheduler-v2: routed client potfile %q to ClientPotfilePath", p)
+			}
+			continue
+		}
+
+		// Recover the wordlist UUID by matching the sanitized on-disk basename.
+		wordlistID, found := c.lookupClientWordlistID(ctx, clientID, filename)
+		if !found {
+			debug.Warning("scheduler-v2: could not resolve client wordlist %q (client %s); leaving in generic wordlist paths",
+				p, clientID)
+			remaining = append(remaining, p)
+			continue
+		}
+
+		// Append path + ID together so indices stay aligned (the agent pairs
+		// ClientWordlistPaths[i] with ClientWordlistIDs[i]).
+		payload.ClientWordlistPaths = append(payload.ClientWordlistPaths, p)
+		payload.ClientWordlistIDs = append(payload.ClientWordlistIDs, wordlistID)
+		// Combinator (-a 1) reads two wordlists positionally, so the ref must
+		// also stay in WordlistPaths at its slot; other modes don't.
+		if payload.AttackMode == AttackModeCombinator {
+			remaining = append(remaining, p)
+			debug.Info("scheduler-v2: routed client wordlist %q (id %s) to ClientWordlistPaths (kept in WordlistPaths for combinator)", p, wordlistID)
+		} else {
+			debug.Info("scheduler-v2: routed client wordlist %q (id %s) to ClientWordlistPaths", p, wordlistID)
+		}
+	}
+
+	payload.WordlistPaths = remaining
+}
+
+// lookupClientWordlistID finds the client_wordlists row for the given client
+// whose on-disk basename matches filename, returning its ID as a string. We
+// match on filepath.Base(file_path) rather than file_name because file_path is
+// the sanitized on-disk path the wire name derives from, whereas file_name is
+// the raw original upload name (they can differ). Returns found=false on no
+// match or any query/scan error — the caller treats that as a best-effort miss.
+func (c *Cycle) lookupClientWordlistID(ctx context.Context, clientID uuid.UUID, filename string) (string, bool) {
+	rows, err := c.db.QueryContext(ctx,
+		`SELECT id, file_path FROM client_wordlists WHERE client_id = $1`, clientID)
+	if err != nil {
+		debug.Warning("scheduler-v2: query client_wordlists for client %s failed: %v", clientID, err)
+		return "", false
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id, filePath string
+		if err := rows.Scan(&id, &filePath); err != nil {
+			debug.Warning("scheduler-v2: scan client_wordlists row for client %s failed: %v", clientID, err)
+			return "", false
+		}
+		if filepath.Base(filePath) == filename {
+			return id, true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		debug.Warning("scheduler-v2: iterate client_wordlists for client %s failed: %v", clientID, err)
+	}
+	return "", false
 }
 
 // readOverflowMode reads the agent_overflow_allocation_mode setting,


### PR DESCRIPTION
## Problem

Closes #67. Client-specific wordlists (and client potfiles) were never synced to agents at job dispatch — a fresh agent failed the job, and a client wordlist changed on the server was never refreshed. This is the follow-up to #61 / PR #63, which fixed the same class of bug for **global** wordlists and rules but deliberately left client-scoped files out.

## Root cause

Client wordlists/potfiles are separate entities (`client_wordlists` / `client_potfiles` tables, `wordlists/clients/{clientID}/...` on disk, dedicated authenticated download endpoints, dedicated agent handling). The v2 scheduler resolved a `client:UUID` / `potfile:ID` job reference down to a flat path and dropped it into the **generic** `WordlistPaths`, never populating the dedicated `ClientWordlistPaths` / `ClientWordlistIDs` / `ClientPotfilePath` fields. As a result:

- `attachFileMD5s` queried only the global `wordlists` table → no MD5 → a stale copy was never refreshed.
- the `/api/files/...` download handler flattened `clients/{uuid}/{file}` (dropping the `{uuid}` dir) → 404 on a fresh download.

The agent's dedicated client-list path (`ensureClientWordlists` / `ensureClientPotfile` → UUID/client endpoints, id→client path-move, post-task `cleanupSensitiveFiles`) already existed and was correct — it was simply never fed.

## Fix

Backend-only routing plus a small agent arg-builder addition; **no schema change, no new endpoints.**

- **backend/scheduler (`cycle.go`)** — `routeClientLists` (called before `attachFileMD5s`) reclassifies `wordlists/clients/{clientID}/{file}` refs out of the generic `WordlistPaths` into the dedicated client fields, recovering the wordlist UUID from `client_wordlists` (matched on the sanitized `filepath.Base(file_path)`). Best-effort — unresolved refs are logged and left in place. Pure `classifyClientWordlistPath` + `lookupClientWordlistID` helpers.
- **Combinator (`-a 1`)** — keeps client refs positional in `WordlistPaths` (two ordered slots) *and* populates the dedicated fields; the agent's `ensureWordlists` skips `wordlists/clients/` paths so they don't 404 on the generic endpoint while still being downloaded/cleaned by the client path.
- **agent (`hashcat_executor.go`)** — `selectHybridWordlist` so hybrid modes 6/7 honor a client wordlist/potfile when `WordlistPaths` is empty.
- **backend/handlers (`user_jobs.go`)** — extracted `resolveWordlistName` so `GetJobDetail` resolves `client:` / `potfile:` IDs to their display names instead of throwing `strconv.Atoi` warnings every poll and rendering `Unknown` in the job-detail view.

## Testing

Verified live end-to-end on the dev stack with a mock agent (mode-0 job referencing a client wordlist):

- backend logged `routeClientLists: routed client wordlist … to ClientWordlistPaths`
- agent downloaded via `GET /api/agent/client-wordlists/{uuid}`, did the id→client path-move, ran, and the job reached `completed`
- `cleanupSensitiveFiles` removed the client wordlist afterward

Added `TestClassifyClientWordlistPath` (client wordlist / client potfile / global / association / malformed).

## Notes

- Confirmed the wire contract matches on both sides (`client_id` / `client_potfile_path` / `client_wordlist_paths` / `client_wordlist_ids`).
- `CHANGELOG.md` is intentionally not part of this PR (tracked separately on the changelog branch).

https://claude.ai/code/session_01Ee3DE6p1bmqBudacCSCmwR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixes client-scoped wordlist/potfile routing during scheduler dispatch so client MD5 refreshes and downloads stay in sync, hashcat command construction uses the correct hybrid dictionaries, and job details render the proper wordlist display names—without changing any API/DB contracts.  

- **Backend**
  - Scheduler dispatch cycle now classifies `wordlists/clients/{clientID}/{filename}` entries, routes `potfile.txt` into `ClientPotfilePath`, converts other client wordlists into aligned `ClientWordlistPaths` + restored `ClientWordlistIDs`, and preserves combinator positional references while removing routed client refs from generic `WordlistPaths` (best-effort).
  - Job detail name resolution now supports global wordlist IDs, `client:UUID` wordlists, and `potfile:ID` potfiles via a shared resolver, keeping `wordlist_names` positionally aligned with `wordlist_ids`.
  - Generic wordlist download logic skips any `WordlistPaths` under `wordlists/clients/` to ensure client assets are handled by dedicated client mechanisms.
  - Adds `TestClassifyClientWordlistPath` to validate correct client-path classification and reject malformed/wrong-prefix/empty inputs.
  - Adds local-path safety checks by validating client wordlist/potfile paths with `resolveDataPath` before filesystem access or passing paths into hashcat (prevents absolute-path and traversal).
- **Agent**
  - Hybrid dictionary selection in `HashcatExecutor` now chooses a usable wordlist path for hybrid modes by preferring `WordlistPaths[0]`, otherwise using the first on-disk client wordlist (`ClientWordlistPaths[0]`), otherwise using `ClientPotfilePath` when it exists.
  - Hybrid attack argument construction updated for both hybrid modes (6/7) to append `wordlist`/`assignment.Mask` in the correct order using the new selector.
  - Client-supplied wordlist/potfile paths are validated via `resolveDataPath` and checked for existence before being appended to hashcat arguments.
- **Frontend**
  - Indirectly improved: job details now return correct `wordlist_names` for combined-wordlist displays for client/potfile references.
- **Docs**
  - No documentation changes.

**Migrations/API:** No database migrations, no API/contract changes, and no breaking changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->