### PR TITLE
fix(backend): running-task progress stuck at 99.99% on salted hash types

### DIFF
--- a/backend/internal/services/job_execution_service.go
+++ b/backend/internal/services/job_execution_service.go
@@ -2416,6 +2416,48 @@ func (s *JobExecutionService) DispatchBenchmarkStormNotification(
 	})
 }
 
+// chunkLocalProgressPercent computes a task's chunk-local progress percentage
+// in BASE (wordlist) units, which is immune to salt/rule drift and never
+// overflows int64 -- the same basis the job/layer calc uses in
+// job_progress_calculation_service.go.
+//
+// keyspaceProcessed is the base restore point (stored ABSOLUTELY while a
+// keyspace-split task runs, RELATIVELY once complete); keyspaceStart/keyspaceEnd
+// are the task's base chunk bounds. agentPercent is the agent's already
+// chunk-local ratio, used only as a fallback when the task has no usable base
+// chunk span. The returned percent is capped at 99.99 (100.0 is reserved for
+// terminal completion writes). baseProc is the chunk-relative base progress,
+// returned so the caller can scale it into effective units.
+func chunkLocalProgressPercent(keyspaceProcessed, keyspaceStart, keyspaceEnd int64, agentPercent float64) (percent float64, baseProc int64) {
+	chunkSize := keyspaceEnd - keyspaceStart // base words
+	if keyspaceStart > 0 && keyspaceProcessed >= keyspaceStart {
+		baseProc = keyspaceProcessed - keyspaceStart // absolute -> chunk-relative
+	} else {
+		baseProc = keyspaceProcessed // already relative, or keyspaceStart == 0
+	}
+	if baseProc < 0 {
+		baseProc = 0
+	}
+	if chunkSize > 0 && baseProc > chunkSize {
+		baseProc = chunkSize
+	}
+
+	if chunkSize > 0 {
+		percent = float64(baseProc) / float64(chunkSize) * 100.0
+	} else {
+		// Degenerate/legacy task without a base chunk span: fall back to the
+		// agent's already chunk-local ratio.
+		percent = agentPercent
+	}
+	if percent >= 100.0 {
+		percent = 99.99 // reserve 100.0 for terminal completion writes (CompleteTask / code-6 path)
+	}
+	if percent < 0 {
+		percent = 0
+	}
+	return percent, baseProc
+}
+
 // UpdateTaskProgress updates the progress of a task accounting for rule splitting and keysplit tasks
 func (s *JobExecutionService) UpdateTaskProgress(ctx context.Context, taskID uuid.UUID, keyspaceProcessed int64, effectiveProgress int64, hashRate *int64, progressPercent float64) error {
 	// Get the task to check for keysplit
@@ -2424,53 +2466,41 @@ func (s *JobExecutionService) UpdateTaskProgress(ctx context.Context, taskID uui
 		return fmt.Errorf("failed to get task for progress update: %w", err)
 	}
 
-	// For keysplit tasks with EffectiveKeyspaceStart > 0, convert absolute to relative
-	// Hashcat reports progress[0] as cumulative absolute position in the keyspace
-	// For continuation tasks (keyspace_start > 0), we need to store the RELATIVE contribution
-	// Example: Task 2 with effective_keyspace_start=492B reports progress[0]=735B at completion
-	//          We should store 735B - 492B = 243B as the task's contribution
-	effectiveKeyspaceProcessed := effectiveProgress
-	if task.IsKeyspaceSplit && task.EffectiveKeyspaceStart != nil && task.EffectiveKeyspaceStart.IsPositive() {
-		if task.EffectiveKeyspaceStart.CmpInt64(effectiveProgress) <= 0 {
-			effectiveKeyspaceProcessed = effectiveProgress - task.EffectiveKeyspaceStart.Int64()
-			debug.Log("Converted absolute to relative effective keyspace for keysplit task", map[string]interface{}{
-				"task_id":                      taskID,
-				"effective_progress_raw":       effectiveProgress,
-				"effective_keyspace_start":     task.EffectiveKeyspaceStart.String(),
-				"effective_keyspace_processed": effectiveKeyspaceProcessed,
-			})
-		}
-		// If effectiveProgress < EffectiveKeyspaceStart, keep original (shouldn't happen but be safe)
-	}
-
-	// Step 11r: recalculate progress_percent as a CHUNK-local fraction.
-	// The agent sends progress_percent as hashcat's absolute ratio
-	// (progress[0]/progress[1]). For chunks dispatched at --skip > 0,
-	// this starts high (e.g., 51% baseline for a chunk at job midpoint)
-	// — confusing display because the chunk hasn't done that much
-	// work; it's just sitting at a high absolute coordinate.
+	// Step 11r: recalculate progress_percent as a CHUNK-local fraction in
+	// BASE (wordlist) units. A single chunk should read 0% -> 100% over its
+	// own lifetime.
 	//
-	// User-expected behavior: a single chunk reads 0% → 100% over its
-	// own lifetime. Use the chunk-relative values we just computed
-	// above: chunk_percent = effective_processed / chunk_effective_size × 100.
-	if task.EffectiveKeyspaceStart != nil && task.EffectiveKeyspaceEnd != nil {
+	// Why BASE and not effective units: the agent's hashcat progress[0]
+	// (effectiveProgress) is in base x rules units -- it does NOT include the
+	// salt count. But the task's effective_keyspace_* fields are salt-adjusted
+	// (base x rules x salts, set at job creation "to match progress[1]"). On a
+	// salted hash type those two operands live in different unit systems, so
+	// dividing the salt-free numerator by the salt-inflated chunk span pushed
+	// the ratio past 100% for every running chunk and pinned the display at the
+	// reserved 99.99. Base units are immune to salt/rule drift and never
+	// overflow int64, which is exactly why the job/layer calc in
+	// job_progress_calculation_service.go was moved to base units too.
+	chunkSize := task.KeyspaceEnd - task.KeyspaceStart
+	progressPercent, baseProc := chunkLocalProgressPercent(keyspaceProcessed, task.KeyspaceStart, task.KeyspaceEnd, progressPercent)
+
+	// Store effective_keyspace_processed consistent with the task's
+	// salt-adjusted effective chunk span: scale the chunk-relative base
+	// progress by (effective_chunk / base_chunk). big.Int multiply-then-divide
+	// keeps this overflow-safe with no int64 truncation (the old code stored
+	// the salt-free absolute progress[0] here, which the job-level calc then
+	// preferred, understating effective processed on salted jobs).
+	effProc := models.NewBigInt(baseProc)
+	if task.EffectiveKeyspaceStart != nil && task.EffectiveKeyspaceEnd != nil && chunkSize > 0 {
 		chunkEff := task.EffectiveKeyspaceEnd.Sub(*task.EffectiveKeyspaceStart)
 		if chunkEff.IsPositive() {
-			localPercent := float64(effectiveKeyspaceProcessed) / float64(chunkEff.Int64()) * 100.0
-			if localPercent >= 100.0 {
-				localPercent = 99.99 // reserve 100.0 for terminal completion writes (CompleteTask / code-6 path)
-			}
-			if localPercent < 0 {
-				localPercent = 0
-			}
-			progressPercent = localPercent
+			effProc = models.NewBigInt(baseProc).Mul(chunkEff).DivInt64(chunkSize)
 		}
 	}
 
 	// Update the task progress
 	// Note: Job-level progress is now calculated by the polling service (JobProgressCalculationService)
 	// which runs every 2 seconds and recalculates from task data
-	err = s.jobTaskRepo.UpdateProgress(ctx, taskID, keyspaceProcessed, models.NewBigInt(effectiveKeyspaceProcessed), hashRate, progressPercent)
+	err = s.jobTaskRepo.UpdateProgress(ctx, taskID, keyspaceProcessed, effProc, hashRate, progressPercent)
 	if err != nil {
 		return fmt.Errorf("failed to update task progress: %w", err)
 	}

--- a/backend/internal/services/job_execution_service_test.go
+++ b/backend/internal/services/job_execution_service_test.go
@@ -165,3 +165,107 @@ func TestJobExecutionService_CanInterruptJob(t *testing.T) {
 func TestJobExecutionService_CanInterruptJob_Disabled(t *testing.T) {
 	t.Skip("Skipping due to architecture limitation: service requires concrete repository types")
 }
+
+// TestChunkLocalProgressPercent covers the base-unit per-task progress
+// calculation. It is a regression guard for the bug where running tasks on
+// salted hash types all displayed a static 99.99%: the old calc divided the
+// agent's salt-free progress[0] by a salt-adjusted (base x rules x salts) chunk
+// span, so the ratio exceeded 100% for every running chunk and was clamped to
+// the reserved 99.99. Computing in BASE units removes the salt/rule drift.
+func TestChunkLocalProgressPercent(t *testing.T) {
+	const (
+		b       = int64(1_000_000_000) // 1B
+		epsilon = 0.01
+	)
+
+	cases := []struct {
+		name              string
+		keyspaceProcessed int64
+		keyspaceStart     int64
+		keyspaceEnd       int64
+		agentPercent      float64
+		wantPercent       float64
+		wantBaseProc      int64
+	}{
+		{
+			// The reported bug: a salted mid-keyspace chunk 25% into its own
+			// span. Pre-fix this rendered 99.99; it must now read ~25%.
+			// restore_point is ABSOLUTE while running: 140B + 25%*(30B) = 147.5B.
+			name:              "salted mid-keyspace chunk reads real progress",
+			keyspaceProcessed: 147_500 * (b / 1000), // 147.5B
+			keyspaceStart:     140 * b,
+			keyspaceEnd:       170 * b,
+			wantPercent:       25.0,
+			wantBaseProc:      7_500 * (b / 1000), // 7.5B
+		},
+		{
+			// First chunk: KeyspaceStart == 0, restore point is already
+			// chunk-relative (absolute == relative).
+			name:              "first chunk (start=0) halfway",
+			keyspaceProcessed: 16 * b,
+			keyspaceStart:     0,
+			keyspaceEnd:       32 * b,
+			wantPercent:       50.0,
+			wantBaseProc:      16 * b,
+		},
+		{
+			// A chunk that has processed its entire span reads 99.99, not 100
+			// (100 is reserved for terminal completion writes).
+			name:              "full chunk caps at 99.99",
+			keyspaceProcessed: 170 * b,
+			keyspaceStart:     140 * b,
+			keyspaceEnd:       170 * b,
+			wantPercent:       99.99,
+			wantBaseProc:      30 * b,
+		},
+		{
+			// Restore point overshoots the chunk end: baseProc clamps to the
+			// chunk size, percent caps at 99.99.
+			name:              "overshoot clamps to chunk size",
+			keyspaceProcessed: 175 * b,
+			keyspaceStart:     140 * b,
+			keyspaceEnd:       170 * b,
+			wantPercent:       99.99,
+			wantBaseProc:      30 * b,
+		},
+		{
+			// Degenerate task without a base chunk span falls back to the
+			// agent's already chunk-local ratio.
+			name:              "no base span falls back to agent percent",
+			keyspaceProcessed: 5 * b,
+			keyspaceStart:     100 * b,
+			keyspaceEnd:       100 * b,
+			agentPercent:      42.5,
+			wantPercent:       42.5,
+			wantBaseProc:      5 * b,
+		},
+		{
+			// Fallback still honors the terminal-write cap.
+			name:              "no base span with >=100 agent percent caps at 99.99",
+			keyspaceProcessed: 0,
+			keyspaceStart:     100 * b,
+			keyspaceEnd:       100 * b,
+			agentPercent:      100.0,
+			wantPercent:       99.99,
+			wantBaseProc:      0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPercent, gotBaseProc := chunkLocalProgressPercent(
+				tc.keyspaceProcessed, tc.keyspaceStart, tc.keyspaceEnd, tc.agentPercent)
+
+			diff := gotPercent - tc.wantPercent
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff > epsilon {
+				t.Errorf("percent = %.4f, want %.4f", gotPercent, tc.wantPercent)
+			}
+			if gotBaseProc != tc.wantBaseProc {
+				t.Errorf("baseProc = %d, want %d", gotBaseProc, tc.wantBaseProc)
+			}
+		})
+	}
+}

--- a/docs/developer/agent.md
+++ b/docs/developer/agent.md
@@ -572,9 +572,14 @@ func (jm *JobManager) calculateProgress(hashcatStatus map[string]interface{}) fl
     `calculateProgress` returns hashcat's **absolute** ratio over the whole job. For a chunk
     dispatched with `--skip > 0` that starts high — a chunk at the job's midpoint reports ~50% on
     its very first update. The backend therefore **recomputes** the reported percent as a
-    *chunk-local* fraction — `effective_processed / chunk_effective_size × 100` — and **caps a
+    *chunk-local* fraction in **base (wordlist) units** —
+    `(keyspace_processed − keyspace_start) / (keyspace_end − keyspace_start) × 100` — and **caps a
     running chunk at 99.99%**, reserving 100% for a terminal completion write, so each chunk reads
     0% → 100% over its own lifetime (`backend/internal/services/job_execution_service.go`, "Step 11r").
+    Base units are used rather than effective (`base × rules × salts`) units because hashcat's
+    `progress[0]` excludes the salt count; dividing that salt-free value by a salt-adjusted chunk span
+    made salted jobs (e.g. NetNTLMv2) report a static 99.99%. This mirrors the drift-free base-unit
+    basis the job/layer calc uses in `job_progress_calculation_service.go`.
 
 ## WebSocket Communication
 


### PR DESCRIPTION
## Problem

On **salted** hash types (NetNTLMv2/5600, NTLM, Kerberos, …) every running task's **Progress** column displayed a static **99.99%** regardless of actual progress, while completed tasks correctly showed 100%. Confirmed fixed in-app (a running chunk now reads e.g. `10.95%` and climbs over its own lifetime).

## Root cause

`UpdateTaskProgress` ("Step 11r", `backend/internal/services/job_execution_service.go`) recomputed the chunk-local percentage as `effective_progress / chunk_effective_span`. Those operands live in **different unit systems** on salted jobs:

- **Numerator** — the agent's hashcat `progress[0]` — is `base × rules`, **no salts** (`agent/internal/jobs/hashcat_executor.go`, `models/jobs.go` `EffectiveProgress`).
- **Denominator** — the task's `effective_keyspace_start/end` — is salt-adjusted `base × rules × salts` (set at job creation "to match `progress[1]`", `job_execution_service.go:348-373`).

The salt-inflated `EffectiveKeyspaceStart` was never `<=` the salt-free `progress[0]`, so the absolute→relative guard was skipped and an *absolute* cumulative progress was divided by *one small chunk span* → ratio ≥ 100% → clamped to the reserved `99.99` for every running chunk past the first. Non-salted jobs were unaffected.

### When it regressed
- The NUMERIC keyspace migration folded salt count into effective keyspace → salted jobs began computing ≥ 100%.
- The symptom became the visible static `99.99` when the running-task cap changed `100 → 99.99`.
- The **job/layer** calc was later hardened to base units (`job_progress_calculation_service.go`, *"584% was observed … Base coverage is immune to salt/rule drift"*) — but the **per-task** path was never given the same treatment. This PR closes that gap.

## Fix

- **backend**: recompute `progress_percent` in **BASE (wordlist) units** via a new pure helper `chunkLocalProgressPercent()` — `(keyspace_processed − keyspace_start) / (keyspace_end − keyspace_start) × 100` — mirroring the drift-free job/layer calc. Immune to salt/rule drift and never overflows int64.
- **backend**: store `effective_keyspace_processed` consistently by scaling the chunk-relative base progress into the task's effective chunk span with `big.Int` multiply-then-divide (removes the salt-free-into-effective mismatch **and** the `BigInt.Int64()` truncation risk for keyspaces > 9.2e18).
- **test**: `TestChunkLocalProgressPercent` (`unit` build tag) — regression guard asserting a salted mid-keyspace chunk reads real progress (~25%) not 99.99, plus first-chunk, cap-at-99.99, overshoot-clamp, and degenerate-span fallback cases.
- **docs**: correct `docs/developer/agent.md` to describe the base-unit recompute and why effective units break on salted jobs.

**No schema change, no migration, no frontend change** — the `Math.min(p, 99.99)` running-task clamp is intentional (reserves 100% for terminal completion).

## Testing

- `cd backend && go test -tags unit ./internal/services/ -run TestChunkLocalProgressPercent -v`
- End-to-end confirmed in-app on a salted job: running tasks now show real per-task progress instead of a uniform 99.99%.
- Note: mock (`--test-mode`) agents cannot reproduce this — they emit chunk-relative, salt-adjusted progress, which computed correctly even under the old code. Real hashcat's absolute, salt-free `progress[0]` is required to trip the bug.

https://claude.ai/code/session_01G2HWL8Wd2xhh3kqanycA3W

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes salted-hash running-task progress by recalculating chunk progress in base keyspace units and scaling it safely to effective task units, preventing static 99.99% progress and large-keyspace truncation.

- **Backend**
  - Added overflow-safe progress scaling with `big.Int`.
  - Clamps overshoot and preserves the intentional 99.99% running-task cap.
  - Added regression coverage for salted, initial, terminal, overshot, and degenerate chunks.
- **Agent/docs**
  - Documented base-unit progress calculation and terminal-progress behavior.
- **API/database/frontend**
  - No API or contract changes, database migrations, breaking changes, or frontend changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->