### PR TITLE
fix(backend,frontend,docs): keyspace pre-flight must not fail job creation

### DIFF
--- a/backend/db/migrations/20260815160000_add_base_keyspace_estimated.down.sql
+++ b/backend/db/migrations/20260815160000_add_base_keyspace_estimated.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE scheduling_units
+    DROP COLUMN IF EXISTS base_keyspace_estimated;
+
+ALTER TABLE job_executions
+    DROP COLUMN IF EXISTS base_keyspace_estimated;

--- a/backend/db/migrations/20260815160000_add_base_keyspace_estimated.up.sql
+++ b/backend/db/migrations/20260815160000_add_base_keyspace_estimated.up.sql
@@ -1,0 +1,26 @@
+-- Track when base_keyspace is an upper-bound estimate rather than hashcat's own
+-- --keyspace output.
+--
+-- Background: base_keyspace is the coordinate space chunk ranges are expressed
+-- in, and unlike effective_keyspace it has no downstream corrector — the forced
+-- agent benchmark refines effective_keyspace from progress[1] but never touches
+-- base. When the --keyspace pre-flight times out on a very large wordlist we now
+-- fall back to the stored wordlists.word_count so the job can still run, but that
+-- count is an UPPER bound (hashcat skips over-length words), so the final chunk
+-- can ask for a range hashcat cannot process. Flagging it lets the dispatcher
+-- tolerate a short tail instead of stranding the job just below 100%.
+--
+-- Distinct from is_accurate_keyspace, which is about effective_keyspace and is
+-- expected to be false until the benchmark lands.
+
+ALTER TABLE job_executions
+    ADD COLUMN IF NOT EXISTS base_keyspace_estimated BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE scheduling_units
+    ADD COLUMN IF NOT EXISTS base_keyspace_estimated BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN job_executions.base_keyspace_estimated IS
+    'TRUE when base_keyspace came from stored word counts because hashcat --keyspace timed out. Upper bound: the dispatcher must tolerate a short final gap.';
+
+COMMENT ON COLUMN scheduling_units.base_keyspace_estimated IS
+    'Mirrors job_executions.base_keyspace_estimated for the unit the scheduler dispatches against.';

--- a/backend/db/migrations/20260815160100_add_keyspace_estimate_notification_type.down.sql
+++ b/backend/db/migrations/20260815160100_add_keyspace_estimate_notification_type.down.sql
@@ -1,0 +1,4 @@
+-- No-op: PostgreSQL does not support removing a value from an enum type without
+-- recreating the type and rewriting every dependent column (notifications.notification_type,
+-- audit_log.event_type, notification_preferences.notification_type). The leftover
+-- 'keyspace_estimate_used' enum value is harmless if this migration is rolled back.

--- a/backend/db/migrations/20260815160100_add_keyspace_estimate_notification_type.up.sql
+++ b/backend/db/migrations/20260815160100_add_keyspace_estimate_notification_type.up.sql
@@ -1,0 +1,12 @@
+-- Add the 'keyspace_estimate_used' notification type.
+--
+-- Emitted when a job is created but hashcat --keyspace did not finish within
+-- keyspace_calculation_timeout_minutes, so base_keyspace fell back to the
+-- wordlist's stored word count. The job runs normally — this tells the operator
+-- their timeout is too low for that wordlist, which otherwise only shows up in
+-- backend logs that are silent whenever DEBUG=false.
+--
+-- ALTER TYPE ... ADD VALUE is safe inside migrate's transaction here because the
+-- new value is only ADDED (not used) in this migration.
+
+ALTER TYPE notification_type ADD VALUE IF NOT EXISTS 'keyspace_estimate_used';

--- a/backend/internal/handlers/jobs/user_jobs.go
+++ b/backend/internal/handlers/jobs/user_jobs.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -712,6 +713,56 @@ func (h *UserJobsHandler) ListLoopbackSessions(w http.ResponseWriter, r *http.Re
 	json.NewEncoder(w).Encode(sessions)
 }
 
+// jobCreationFailure records one preset or workflow step that could not be
+// turned into a job, so the caller learns which item failed and why instead of
+// receiving a bare "No jobs were created".
+type jobCreationFailure struct {
+	// PresetJobID is empty for a custom job (there is only ever one).
+	PresetJobID string `json:"preset_job_id,omitempty"`
+	// Name is the preset/step name when known — more use to a human than a UUID.
+	Name  string `json:"name,omitempty"`
+	Error string `json:"error"`
+}
+
+// isKeyspaceError reports whether a job-creation error is about keyspace, and
+// should therefore be a 400 (the caller can act on it — usually by raising the
+// keyspace timeout or picking a smaller wordlist) rather than a 500.
+//
+// Shared by all three creation branches so a keyspace failure reads the same
+// whether the job came from a custom config, a preset, or a workflow step.
+func isKeyspaceError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	for _, marker := range []string{"keyspace", "overflow", "exceeds", "too large"} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// writeJobCreationFailure sends the response for a request where nothing could
+// be created. It reports the first real error instead of a generic message, and
+// maps keyspace problems to 400 so the UI can show them as actionable.
+func writeJobCreationFailure(w http.ResponseWriter, failures []jobCreationFailure, firstErr error) {
+	if firstErr == nil {
+		http.Error(w, "No jobs were created", http.StatusInternalServerError)
+		return
+	}
+
+	status := http.StatusInternalServerError
+	prefix := "Failed to create job"
+	if isKeyspaceError(firstErr) {
+		status = http.StatusBadRequest
+		prefix = "Keyspace error"
+	}
+
+	msg := fmt.Sprintf("%s: %s", prefix, firstErr.Error())
+	if len(failures) > 1 {
+		msg = fmt.Sprintf("%s (%d of %d items failed; first error shown)", msg, len(failures), len(failures))
+	}
+	http.Error(w, msg, status)
+}
+
 // CreateJobFromHashlist handles POST /api/hashlists/{id}/create-job
 func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -773,6 +824,13 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 	}
 
 	var createdJobs []string
+	// Per-item failures, collected rather than discarded. A request can ask for
+	// several presets or a multi-step workflow; previously any that failed were
+	// logged and skipped, so the caller got either a bare "No jobs were created"
+	// with no reason, or — worse — a 201 that silently dropped the steps that
+	// failed. Both hid real problems (a keyspace timeout looked identical to a
+	// deleted preset), and with DEBUG off the log line did not exist either.
+	var failures []jobCreationFailure
 
 	switch jobType.Type {
 	case "preset":
@@ -804,6 +862,10 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 			presetJob, err := h.presetJobRepo.GetByID(ctx, presetJobID)
 			if err != nil {
 				debug.Error("Failed to get preset job %s: %v", presetJobID, err)
+				failures = append(failures, jobCreationFailure{
+					PresetJobID: presetJobID.String(),
+					Error:       fmt.Sprintf("preset job could not be loaded: %v", err),
+				})
 				continue
 			}
 
@@ -829,6 +891,11 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 			jobExecution, err := h.jobExecutionService.CreateJobExecution(ctx, presetJobID, hashlistID, &userID, jobName)
 			if err != nil {
 				debug.Error("Failed to create job execution for preset %s: %v", presetJobID, err)
+				failures = append(failures, jobCreationFailure{
+					PresetJobID: presetJobID.String(),
+					Name:        presetJob.Name,
+					Error:       err.Error(),
+				})
 				continue
 			}
 
@@ -862,6 +929,10 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 			workflowID, err := uuid.Parse(workflowIDStr)
 			if err != nil {
 				debug.Error("Invalid workflow ID: %s", workflowIDStr)
+				failures = append(failures, jobCreationFailure{
+					Name:  workflowIDStr,
+					Error: fmt.Sprintf("invalid workflow ID %q", workflowIDStr),
+				})
 				continue
 			}
 
@@ -869,6 +940,10 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 			workflow, err := h.workflowRepo.GetWorkflowByID(ctx, workflowID)
 			if err != nil {
 				debug.Error("Failed to get workflow %s: %v", workflowID, err)
+				failures = append(failures, jobCreationFailure{
+					Name:  workflowIDStr,
+					Error: fmt.Sprintf("workflow could not be loaded: %v", err),
+				})
 				continue
 			}
 			steps := workflow.Steps
@@ -883,6 +958,10 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 				presetJob, err := h.presetJobRepo.GetByID(ctx, step.PresetJobID)
 				if err != nil {
 					debug.Error("Failed to get preset job %s for workflow step: %v", step.PresetJobID, err)
+					failures = append(failures, jobCreationFailure{
+						PresetJobID: step.PresetJobID.String(),
+						Error:       fmt.Sprintf("workflow step preset could not be loaded: %v", err),
+					})
 					continue
 				}
 
@@ -908,6 +987,11 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 				jobExecution, err := h.jobExecutionService.CreateJobExecution(ctx, step.PresetJobID, hashlistID, &userID, jobName)
 				if err != nil {
 					debug.Error("Failed to create job execution for workflow step: %v", err)
+					failures = append(failures, jobCreationFailure{
+						PresetJobID: step.PresetJobID.String(),
+						Name:        presetJob.Name,
+						Error:       err.Error(),
+					})
 					continue
 				}
 
@@ -1134,12 +1218,22 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 			AssociationWordlistName: assocWordlistName,
 		})
 
-		// Ephemeral wordlist pre-filtering (GH #40): when a filter is supplied on a
-		// wordlist-based attack, generate a job-scoped filtered wordlist from the
-		// selected wordlist(s) before creating the job. Generation can take a while
-		// for very large wordlists, so it runs in the background and the request
-		// returns 202; the job is created (and becomes schedulable) only once the
-		// filtered wordlist exists and its keyspace is known.
+		// Custom jobs are always prepared asynchronously.
+		//
+		// Both of the slow steps here are unbounded in the size of the user's
+		// inputs: generating an ephemeral filtered wordlist (GH #40), and the
+		// hashcat --keyspace/--total-candidates pre-flight, each of which reads
+		// the whole wordlist. On a 30 GB list the pre-flight alone can outlast
+		// any sensible request. Doing that inside the POST left the browser
+		// spinning for minutes and then, if the keyspace timeout fired, threw the
+		// work away entirely.
+		//
+		// So: create the row in "preparing" (visible in the jobs table, ignored
+		// by the scheduler), return 202 immediately, and let the background
+		// finalizer flip it to "pending" — or to "failed" with a real reason.
+		// The filtered-wordlist path already worked this way; the plain path now
+		// matches it instead of being the one case that blocks.
+		var filter *models.WordlistFilter
 		if req.CustomJob.Filter != nil && !req.CustomJob.Filter.IsEmpty() {
 			if err := req.CustomJob.Filter.Validate(); err != nil {
 				http.Error(w, fmt.Sprintf("Invalid wordlist filter: %v", err), http.StatusBadRequest)
@@ -1157,56 +1251,32 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 				http.Error(w, "Wordlist filtering requires at least one wordlist", http.StatusBadRequest)
 				return
 			}
-
-			filter := *req.CustomJob.Filter
-
-			// Create the job row immediately in "preparing" so it shows in the jobs
-			// table while the filtered wordlist generates; the scheduler ignores it
-			// until it's finalized to "pending" (GH #40).
-			preparingJob, err := h.jobExecutionService.CreatePreparingFilterJob(ctx, config, hashlistID, &userID, jobName)
-			if err != nil {
-				debug.Error("Failed to create preparing job: %v", err)
-				http.Error(w, fmt.Sprintf("Failed to create job: %v", err), http.StatusInternalServerError)
-				return
-			}
-			go h.prepareAndCreateFilteredCustomJob(preparingJob.ID, config, filter, userID)
-
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusAccepted)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"status":  "preparing",
-				"job_id":  preparingJob.ID.String(),
-				"ids":     []string{preparingJob.ID.String()},
-				"message": "Preparing — generating the filtered wordlist; the job will start automatically once it's ready.",
-			})
-			return
+			filter = req.CustomJob.Filter
 		}
 
-		// Create job execution directly without saving preset
-		jobExecution, err := h.jobExecutionService.CreateCustomJobExecution(ctx, config, hashlistID, &userID, jobName)
+		preparingJob, err := h.jobExecutionService.CreatePreparingJob(ctx, config, hashlistID, &userID, jobName)
 		if err != nil {
-			debug.Error("Failed to create custom job execution: %v", err)
-
-			// Propagate meaningful error messages for keyspace-related errors
-			errMsg := err.Error()
-			if strings.Contains(errMsg, "overflow") || strings.Contains(errMsg, "exceeds") ||
-				strings.Contains(errMsg, "too large") || strings.Contains(errMsg, "keyspace") {
-				http.Error(w, fmt.Sprintf("Keyspace error: %s", errMsg), http.StatusBadRequest)
-				return
-			}
-
-			http.Error(w, fmt.Sprintf("Failed to create job: %s", errMsg), http.StatusInternalServerError)
+			debug.Error("Failed to create preparing job: %v", err)
+			writeJobCreationFailure(w, []jobCreationFailure{{Error: err.Error()}}, err)
 			return
 		}
 
-		createdJobs = append(createdJobs, jobExecution.ID.String())
+		go h.prepareAndFinalizeCustomJob(preparingJob.ID, config, filter, userID, hashlistID,
+			req.CustomJob.Loopback, req.CustomJobName)
 
-		if req.CustomJob.Loopback {
-			h.startLoopbackSession(ctx, hashlistID, models.LoopbackSourceCustom, nil, req.CustomJobName, &userID, []services.LoopbackOrigin{{
-				JobExecutionID: jobExecution.ID,
-				IsMutatable:    models.IsMutatableAttack(config.AttackMode, config.RuleIDs),
-			}})
+		message := "Preparing — calculating keyspace; the job will start automatically once it's ready."
+		if filter != nil {
+			message = "Preparing — generating the filtered wordlist and calculating keyspace; the job will start automatically once it's ready."
 		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status":  "preparing",
+			"job_id":  preparingJob.ID.String(),
+			"ids":     []string{preparingJob.ID.String()},
+			"message": message,
+		})
+		return
 
 	default:
 		http.Error(w, "Invalid job type", http.StatusBadRequest)
@@ -1214,7 +1284,11 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 	}
 
 	if len(createdJobs) == 0 {
-		http.Error(w, "No jobs were created", http.StatusInternalServerError)
+		var firstErr error
+		if len(failures) > 0 {
+			firstErr = errors.New(failures[0].Error)
+		}
+		writeJobCreationFailure(w, failures, firstErr)
 		return
 	}
 
@@ -1224,18 +1298,46 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 		"message": fmt.Sprintf("%d job(s) created successfully", len(createdJobs)),
 	}
 
+	// Partial success: some presets/steps were created and some were not. This
+	// used to return a plain 201, so a workflow could silently lose steps and
+	// the user would never know. Still 201 (jobs were created), but the caller
+	// now gets the list of what did not make it.
+	if len(failures) > 0 {
+		response["failures"] = failures
+		response["message"] = fmt.Sprintf("%d job(s) created, %d failed", len(createdJobs), len(failures))
+		debug.Warning("Job creation partially succeeded for hashlist %d: %d created, %d failed (first: %s)",
+			hashlistID, len(createdJobs), len(failures), failures[0].Error)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(response)
 }
 
-// prepareAndCreateFilteredCustomJob runs in the background for a job already
-// created in the "preparing" state (GH #40). It generates the ephemeral filtered
-// wordlist(s) from the user's selected wordlists, then finalizes the job
-// (computes keyspace, creates scheduling units, flips to "pending") so the
-// scheduler picks it up. Any failure (0-match filter, full disk, etc.) marks the
-// job failed with the reason and removes the partial filtered wordlists.
-func (h *UserJobsHandler) prepareAndCreateFilteredCustomJob(jobID uuid.UUID, config services.CustomJobConfig, filter models.WordlistFilter, userID uuid.UUID) {
+// prepareAndFinalizeCustomJob runs in the background for a job already created
+// in the "preparing" state. It optionally generates the ephemeral filtered
+// wordlist(s) from the user's selected wordlists (GH #40), then finalizes the
+// job (computes keyspace, creates scheduling units, flips to "pending") so the
+// scheduler picks it up. Any failure (0-match filter, full disk, unresolvable
+// wordlist, etc.) marks the job failed with the reason and removes the partial
+// filtered wordlists.
+//
+// filter may be nil, in which case no wordlists are generated and this is purely
+// the asynchronous keyspace pre-flight — the common case, and the reason every
+// custom job now goes through here rather than only filtered ones.
+//
+// Runs on context.Background() deliberately: the HTTP request that started it
+// has already returned 202, so tying this work to the request context would
+// cancel the keyspace calculation the moment the client disconnected.
+func (h *UserJobsHandler) prepareAndFinalizeCustomJob(
+	jobID uuid.UUID,
+	config services.CustomJobConfig,
+	filter *models.WordlistFilter,
+	userID uuid.UUID,
+	hashlistID int64,
+	loopback bool,
+	customJobName string,
+) {
 	ctx := context.Background()
 
 	var filteredIDs models.IDArray
@@ -1259,6 +1361,12 @@ func (h *UserJobsHandler) prepareAndCreateFilteredCustomJob(jobID uuid.UUID, con
 		}
 	}
 
+	if filter == nil {
+		// No pre-filtering: finalize against the user's original wordlists.
+		h.finalizeCustomJob(ctx, jobID, config, hashlistID, userID, loopback, customJobName, failJob)
+		return
+	}
+
 	for _, wlIDStr := range config.WordlistIDs {
 		// Only filter global numeric wordlists. Client/potfile special IDs
 		// (e.g. "client:1", "potfile:2") are passed through unfiltered.
@@ -1269,7 +1377,7 @@ func (h *UserJobsHandler) prepareAndCreateFilteredCustomJob(jobID uuid.UUID, con
 		}
 
 		// Own the ephemeral wordlist by the job from creation so the sweep can find it.
-		wl, err := h.wordlistManager.CreateFilteredWordlistRecord(ctx, parentID, "", "", filter, true, &jobID, userID)
+		wl, err := h.wordlistManager.CreateFilteredWordlistRecord(ctx, parentID, "", "", *filter, true, &jobID, userID)
 		if err != nil {
 			debug.Error("Failed to create ephemeral filtered wordlist from %d: %v", parentID, err)
 			failJob(fmt.Sprintf("could not create filtered wordlist: %v", err))
@@ -1288,13 +1396,45 @@ func (h *UserJobsHandler) prepareAndCreateFilteredCustomJob(jobID uuid.UUID, con
 
 	config.WordlistIDs = filteredIDs
 
-	if err := h.jobExecutionService.FinalizeFilterJob(ctx, jobID, config); err != nil {
-		debug.Error("Failed to finalize filtered custom job %s: %v", jobID, err)
+	debug.Info("Generated %d ephemeral wordlist(s) for job %s; finalizing", len(createdWordlistIDs), jobID)
+	h.finalizeCustomJob(ctx, jobID, config, hashlistID, userID, loopback, customJobName, failJob)
+}
+
+// finalizeCustomJob computes the job's keyspace, creates its scheduling units and
+// flips it from "preparing" to "pending", then starts the loopback session if the
+// user asked for one.
+//
+// Shared by the filtered and unfiltered paths so both surface a failure the same
+// way — as a failed job carrying the reason, which is the only channel the user
+// has left once the request has returned 202.
+//
+// The loopback session is started here rather than at request time because until
+// the job reaches "pending" there is nothing for a session to attach to; a job
+// that fails during preparation should not leave an orphaned session behind.
+func (h *UserJobsHandler) finalizeCustomJob(
+	ctx context.Context,
+	jobID uuid.UUID,
+	config services.CustomJobConfig,
+	hashlistID int64,
+	userID uuid.UUID,
+	loopback bool,
+	customJobName string,
+	failJob func(reason string),
+) {
+	if err := h.jobExecutionService.FinalizeJob(ctx, jobID, config); err != nil {
+		debug.Error("Failed to finalize custom job %s: %v", jobID, err)
 		failJob(fmt.Sprintf("could not finalize job: %v", err))
 		return
 	}
 
-	debug.Info("Finalized filtered custom job %s with %d ephemeral wordlist(s)", jobID, len(createdWordlistIDs))
+	debug.Info("Finalized custom job %s (preparing -> pending)", jobID)
+
+	if loopback {
+		h.startLoopbackSession(ctx, hashlistID, models.LoopbackSourceCustom, nil, customJobName, &userID, []services.LoopbackOrigin{{
+			JobExecutionID: jobID,
+			IsMutatable:    models.IsMutatableAttack(config.AttackMode, config.RuleIDs),
+		}})
+	}
 }
 
 // GetJobDetail handles GET /api/jobs/{id}

--- a/backend/internal/integration/job_websocket_integration.go
+++ b/backend/internal/integration/job_websocket_integration.go
@@ -1409,6 +1409,131 @@ func formatBenchmarkErrorMessage(errorCode, rawError string) string {
 	}
 }
 
+// handleEstimatedKeyspaceOverrun closes out a task that failed with
+// AGENT_NO_WORK because it addressed base-keyspace units past the end of the
+// wordlist hashcat actually indexes.
+//
+// This can only happen on a unit flagged base_keyspace_estimated — i.e. the
+// hashcat --keyspace pre-flight timed out and base_keyspace was taken from
+// wordlists.word_count instead. That count is an upper bound: hashcat skips
+// blank and over-length lines, so its keyspace is at or below the raw line
+// count (on rockyou, 14,344,384 vs 14,344,391). Unlike effective_keyspace,
+// nothing downstream ever corrects base_keyspace, so the tail gap
+// [MAX(range_end), base_keyspace) stays open forever and the job hangs just
+// short of complete.
+//
+// The scope is deliberately narrow. AGENT_NO_WORK on a unit with an exact base
+// keyspace still means what it always meant (a device that never ran — see
+// reportNoWorkIfIdle), and must keep failing loudly; masking it here would hide
+// the autotune-skip class this project has already been bitten by. So all three
+// conditions must hold: the error is AGENT_NO_WORK, the unit's base is an
+// estimate, and the task's range reaches the current tail.
+//
+// Returns true if it handled the task (caller should stop processing).
+func (s *JobWebSocketIntegration) handleEstimatedKeyspaceOverrun(ctx context.Context, agentID int, progress *models.JobProgress) (bool, error) {
+	handled, err := resolveEstimatedKeyspaceOverrun(ctx, s.db, progress.TaskID, progress.ErrorMessage)
+	if err != nil || !handled {
+		return false, err
+	}
+
+	taskIDStr := progress.TaskID.String()
+	s.cacheCompletion(taskIDStr)
+	s.sendTaskCompleteAck(agentID, taskIDStr, true, "keyspace ended earlier than the estimate; range retired")
+	return true, nil
+}
+
+// resolveEstimatedKeyspaceOverrun is the database half of
+// handleEstimatedKeyspaceOverrun: it decides whether this failure is an
+// estimated-keyspace overrun and, if so, records the corrected keyspace and
+// retires the impossible range.
+//
+// Split out from the method so the decision can be tested against a real schema
+// without standing up the websocket handler and agent plumbing that the
+// acknowledgement half needs. All of the behaviour worth testing lives here.
+func resolveEstimatedKeyspaceOverrun(ctx context.Context, database *sql.DB, taskID uuid.UUID, errorMessage string) (bool, error) {
+	if !strings.Contains(strings.ToLower(errorMessage), "agent_no_work") {
+		return false, nil
+	}
+
+	var (
+		unitID     uuid.UUID
+		rangeStart sql.NullInt64
+		rangeEnd   sql.NullInt64
+		base       sql.NullInt64
+		estimated  bool
+	)
+	err := database.QueryRowContext(ctx, `
+		SELECT su.id, jt.range_start, jt.range_end, su.base_keyspace, su.base_keyspace_estimated
+		FROM job_tasks jt
+		JOIN scheduling_units su ON su.id = jt.scheduling_unit_id
+		WHERE jt.id = $1
+	`, taskID).Scan(&unitID, &rangeStart, &rangeEnd, &base, &estimated)
+	if err == sql.ErrNoRows {
+		// Legacy task with no scheduling unit — not our case.
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("load task/unit for overrun check: %w", err)
+	}
+
+	if !estimated || !rangeStart.Valid || !rangeEnd.Valid || !base.Valid {
+		return false, nil
+	}
+	// Only the tail. A no-work failure in the middle of the keyspace is a real
+	// failure — the words are there, so something else went wrong.
+	if rangeEnd.Int64 < base.Int64 {
+		return false, nil
+	}
+	// Guard against shrinking to zero on a unit that has never run: that would
+	// complete a job that did no work at all.
+	if rangeStart.Int64 <= 0 {
+		debug.Warning("Task %s reported no work over the whole estimated keyspace of unit %s; treating as a real failure, not an overrun",
+			taskID, unitID)
+		return false, nil
+	}
+
+	debug.Warning("Estimated base keyspace for unit %s overran the real wordlist size: task %s (range %d-%d) tested nothing. "+
+		"Shrinking base_keyspace %d → %d and closing the tail. Raise Admin Settings > Job Execution > Keyspace Calculation Timeout "+
+		"so hashcat --keyspace can complete and this estimate is not needed.",
+		unitID, taskID, rangeStart.Int64, rangeEnd.Int64, base.Int64, rangeStart.Int64)
+
+	tx, err := database.BeginTx(ctx, nil)
+	if err != nil {
+		return false, fmt.Errorf("begin overrun tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// The real keyspace ends where this task started. Recording it clears the
+	// tail gap for good rather than papering over one dispatch of it.
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE scheduling_units
+		SET base_keyspace = $1, base_keyspace_estimated = FALSE, updated_at = NOW()
+		WHERE id = $2
+	`, rangeStart.Int64, unitID); err != nil {
+		return false, fmt.Errorf("shrink unit base_keyspace: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE job_executions je
+		SET base_keyspace = $1, base_keyspace_estimated = FALSE, updated_at = NOW()
+		FROM scheduling_units su
+		WHERE su.id = $2 AND je.id = su.parent_job_id
+	`, rangeStart.Int64, unitID); err != nil {
+		return false, fmt.Errorf("shrink job base_keyspace: %w", err)
+	}
+	// Drop the impossible interval and task rather than leaving a failed row:
+	// the range no longer exists, so there is nothing to retry or report.
+	if _, err := tx.ExecContext(ctx, `DELETE FROM job_keyspace_intervals WHERE task_id = $1`, taskID); err != nil {
+		return false, fmt.Errorf("delete overrun interval: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM job_tasks WHERE id = $1`, taskID); err != nil {
+		return false, fmt.Errorf("delete overrun task: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("commit overrun fix: %w", err)
+	}
+	return true, nil
+}
+
 // HandleJobProgress processes job progress updates from agents
 func (s *JobWebSocketIntegration) HandleJobProgress(ctx context.Context, agentID int, progress *models.JobProgress) error {
 	debug.Log("Processing job progress from agent", map[string]interface{}{
@@ -1756,6 +1881,20 @@ func (s *JobWebSocketIntegration) HandleJobProgress(ctx context.Context, agentID
 			s.cacheCompletion(taskIDStr)
 			s.sendTaskCompleteAck(agentID, taskIDStr, true, "task rejected (race): "+progress.ErrorMessage)
 
+			return nil
+		}
+
+		// Estimated-keyspace overrun: the unit's base_keyspace came from stored
+		// word counts (the --keyspace pre-flight timed out), which is an UPPER
+		// bound, so the final chunk can address words past the end of what
+		// hashcat actually indexes. hashcat then exits 0 having tested nothing
+		// and the agent reports AGENT_NO_WORK. Treating that as a transient
+		// failure re-dispatches the same impossible range forever and strands
+		// the job just short of 100%. Instead, take it as the measurement it is
+		// — the real keyspace ends here — and shrink the unit to match.
+		if handled, hErr := s.handleEstimatedKeyspaceOverrun(ctx, agentID, progress); hErr != nil {
+			debug.Warning("estimated-keyspace overrun check for task %s: %v", progress.TaskID, hErr)
+		} else if handled {
 			return nil
 		}
 

--- a/backend/internal/integration/keyspace_overrun_test.go
+++ b/backend/internal/integration/keyspace_overrun_test.go
@@ -1,0 +1,209 @@
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ZerkerEOD/krakenhashes/backend/internal/db"
+	"github.com/ZerkerEOD/krakenhashes/backend/internal/models"
+	"github.com/ZerkerEOD/krakenhashes/backend/internal/testutil"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests cover resolveEstimatedKeyspaceOverrun, which only ever runs on the
+// degraded path where hashcat's --keyspace pre-flight timed out and
+// base_keyspace came from the wordlist's stored word_count instead.
+//
+// That count is an UPPER bound (hashcat skips blank and over-length lines), so
+// the tail chunk can address words hashcat does not index; hashcat exits 0
+// having tested nothing and the agent reports AGENT_NO_WORK. Without this
+// handling the tail gap never closes and the job hangs just short of 100% — the
+// same failure class as GH #62.
+//
+// The risk in the other direction is worse: AGENT_NO_WORK is also how a device
+// that never ran reports itself (kernel autotune skip). Swallowing that would
+// hide a real fault, so most of what follows asserts the guard does NOT fire.
+
+// overrunFixture builds a job + scheduling unit + task + interval and returns
+// the unit and task IDs. baseKeyspace is the (possibly over-estimated) unit
+// base; the task covers [rangeStart, rangeEnd).
+func overrunFixture(t *testing.T, database *db.DB, estimated bool, baseKeyspace, rangeStart, rangeEnd int64) (unitID, taskID uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+
+	suffix := uuid.NewString()[:8]
+	user := testutil.CreateTestUser(t, database, "overrun-"+suffix, "overrun-"+suffix+"@test.local", testutil.DefaultTestPassword, "user")
+
+	var hashlistID int64
+	require.NoError(t, database.QueryRowContext(ctx, `
+		INSERT INTO hashlists (name, user_id, hash_type_id, status)
+		VALUES ('overrun-test', $1, 0, $2)
+		RETURNING id
+	`, user.ID, models.HashListStatusReady).Scan(&hashlistID))
+
+	jobID := uuid.New()
+	_, err := database.ExecContext(ctx, `
+		INSERT INTO job_executions (id, hashlist_id, attack_mode, priority, base_keyspace, base_keyspace_estimated)
+		VALUES ($1, $2, 0, 0, $3, $4)
+	`, jobID, hashlistID, baseKeyspace, estimated)
+	require.NoError(t, err)
+
+	unitID = uuid.New()
+	_, err = database.ExecContext(ctx, `
+		INSERT INTO scheduling_units (id, parent_job_id, layer_index, status, attack_mode,
+		                              effective_keyspace, base_keyspace, base_keyspace_estimated)
+		VALUES ($1, $2, 0, 'pending', 0, $3, $4, $5)
+	`, unitID, jobID, baseKeyspace, baseKeyspace, estimated)
+	require.NoError(t, err)
+
+	taskID = uuid.New()
+	_, err = database.ExecContext(ctx, `
+		INSERT INTO job_tasks (id, job_execution_id, scheduling_unit_id, keyspace_start, keyspace_end,
+		                       range_start, range_end, chunk_duration, status)
+		VALUES ($1, $2, $3, $4, $5, $4, $5, 60, 'running')
+	`, taskID, jobID, unitID, rangeStart, rangeEnd)
+	require.NoError(t, err)
+
+	_, err = database.ExecContext(ctx, `
+		INSERT INTO job_keyspace_intervals (id, scheduling_unit_id, range_start, range_end, status, task_id)
+		VALUES ($1, $2, $3, $4, 'running', $5)
+	`, uuid.New(), unitID, rangeStart, rangeEnd, taskID)
+	require.NoError(t, err)
+
+	return unitID, taskID
+}
+
+func unitBase(t *testing.T, database *db.DB, unitID uuid.UUID) (base int64, estimated bool) {
+	t.Helper()
+	require.NoError(t, database.QueryRowContext(context.Background(),
+		`SELECT base_keyspace, base_keyspace_estimated FROM scheduling_units WHERE id = $1`,
+		unitID).Scan(&base, &estimated))
+	return
+}
+
+func rowCount(t *testing.T, database *db.DB, query string, arg interface{}) int {
+	t.Helper()
+	var n int
+	require.NoError(t, database.QueryRowContext(context.Background(), query, arg).Scan(&n))
+	return n
+}
+
+const noWorkErr = "AGENT_NO_WORK: hashcat exited 0 without processing any candidates (no status ever reported)"
+
+// The real case: word_count said 14,344,391 but hashcat only indexes
+// 14,344,384, so the last 7-word chunk tests nothing.
+func TestResolveEstimatedKeyspaceOverrun_ShrinksTailAndRetiresRange(t *testing.T) {
+	database := testutil.SetupTestDB(t)
+	unitID, taskID := overrunFixture(t, database, true, 14344391, 14344384, 14344391)
+
+	handled, err := resolveEstimatedKeyspaceOverrun(context.Background(), database.DB, taskID, noWorkErr)
+	require.NoError(t, err)
+	assert.True(t, handled, "an AGENT_NO_WORK tail failure on an estimated base should be handled")
+
+	base, estimated := unitBase(t, database, unitID)
+	assert.Equal(t, int64(14344384), base, "base_keyspace should shrink to where the dead chunk started")
+	assert.False(t, estimated, "base is now measured, not estimated, so the flag should clear")
+
+	assert.Zero(t, rowCount(t, database, `SELECT count(*) FROM job_tasks WHERE id = $1`, taskID),
+		"the impossible task should be removed, not left as a failed row")
+	assert.Zero(t, rowCount(t, database, `SELECT count(*) FROM job_keyspace_intervals WHERE task_id = $1`, taskID),
+		"its interval should go too, so the tail gap does not reopen")
+}
+
+// The parent job must be corrected as well — the units are denormalized from it,
+// so leaving the job's own base stale would resurface on any repopulate.
+func TestResolveEstimatedKeyspaceOverrun_AlsoCorrectsParentJob(t *testing.T) {
+	database := testutil.SetupTestDB(t)
+	unitID, taskID := overrunFixture(t, database, true, 1000, 990, 1000)
+
+	handled, err := resolveEstimatedKeyspaceOverrun(context.Background(), database.DB, taskID, noWorkErr)
+	require.NoError(t, err)
+	require.True(t, handled)
+
+	var jobBase int64
+	var jobEstimated bool
+	require.NoError(t, database.QueryRowContext(context.Background(), `
+		SELECT je.base_keyspace, je.base_keyspace_estimated
+		FROM job_executions je JOIN scheduling_units su ON su.parent_job_id = je.id
+		WHERE su.id = $1
+	`, unitID).Scan(&jobBase, &jobEstimated))
+
+	assert.Equal(t, int64(990), jobBase)
+	assert.False(t, jobEstimated)
+}
+
+// An exact base keyspace means the words really are there, so AGENT_NO_WORK is a
+// device that never ran. This is the autotune-skip case and must stay a failure.
+func TestResolveEstimatedKeyspaceOverrun_IgnoresExactBaseKeyspace(t *testing.T) {
+	database := testutil.SetupTestDB(t)
+	unitID, taskID := overrunFixture(t, database, false, 1000, 990, 1000)
+
+	handled, err := resolveEstimatedKeyspaceOverrun(context.Background(), database.DB, taskID, noWorkErr)
+	require.NoError(t, err)
+	assert.False(t, handled, "must not swallow AGENT_NO_WORK when the base keyspace is exact")
+
+	base, _ := unitBase(t, database, unitID)
+	assert.Equal(t, int64(1000), base, "base must be left alone")
+	assert.Equal(t, 1, rowCount(t, database, `SELECT count(*) FROM job_tasks WHERE id = $1`, taskID),
+		"the task must survive so normal failure handling can run")
+}
+
+// A no-work failure in the middle of the keyspace is not an overrun: the words
+// exist, so something else went wrong and it must be reported.
+func TestResolveEstimatedKeyspaceOverrun_IgnoresMidKeyspaceFailure(t *testing.T) {
+	database := testutil.SetupTestDB(t)
+	unitID, taskID := overrunFixture(t, database, true, 1000, 400, 500)
+
+	handled, err := resolveEstimatedKeyspaceOverrun(context.Background(), database.DB, taskID, noWorkErr)
+	require.NoError(t, err)
+	assert.False(t, handled, "only a range reaching the tail can be an overrun")
+
+	base, estimated := unitBase(t, database, unitID)
+	assert.Equal(t, int64(1000), base)
+	assert.True(t, estimated, "the estimate flag should still stand")
+}
+
+// Shrinking to zero would mark a job complete having tested nothing at all, so a
+// first chunk that reports no work is treated as a real failure.
+func TestResolveEstimatedKeyspaceOverrun_RefusesToShrinkToZero(t *testing.T) {
+	database := testutil.SetupTestDB(t)
+	unitID, taskID := overrunFixture(t, database, true, 1000, 0, 1000)
+
+	handled, err := resolveEstimatedKeyspaceOverrun(context.Background(), database.DB, taskID, noWorkErr)
+	require.NoError(t, err)
+	assert.False(t, handled, "a unit that never produced work must not be silently completed")
+
+	base, _ := unitBase(t, database, unitID)
+	assert.Equal(t, int64(1000), base)
+}
+
+// Any other failure is somebody else's to handle, even on an estimated unit.
+func TestResolveEstimatedKeyspaceOverrun_IgnoresUnrelatedErrors(t *testing.T) {
+	database := testutil.SetupTestDB(t)
+	unitID, taskID := overrunFixture(t, database, true, 1000, 990, 1000)
+
+	for _, msg := range []string{
+		"AGENT_AUTOTUNE: kernel autotune failure skipped the device",
+		"hashcat exited with status 255",
+		"",
+	} {
+		handled, err := resolveEstimatedKeyspaceOverrun(context.Background(), database.DB, taskID, msg)
+		require.NoError(t, err)
+		assert.Falsef(t, handled, "must not fire on %q", msg)
+	}
+
+	base, _ := unitBase(t, database, unitID)
+	assert.Equal(t, int64(1000), base)
+}
+
+// Legacy tasks predate scheduling units; the join finds nothing and the guard
+// must decline rather than error.
+func TestResolveEstimatedKeyspaceOverrun_IgnoresUnknownTask(t *testing.T) {
+	database := testutil.SetupTestDB(t)
+
+	handled, err := resolveEstimatedKeyspaceOverrun(context.Background(), database.DB, uuid.New(), noWorkErr)
+	require.NoError(t, err, "an unknown task is not an error condition")
+	assert.False(t, handled)
+}

--- a/backend/internal/models/notification.go
+++ b/backend/internal/models/notification.go
@@ -29,6 +29,9 @@ const (
 	NotificationTypeWebhookFailure         NotificationType = "webhook_failure"
 	NotificationTypeWordlistRegenFailed    NotificationType = "wordlist_regen_failed"
 	NotificationTypeAnalyticsExport        NotificationType = "analytics_export"
+	// Informational, not a failure: the job runs, but its base keyspace is an
+	// estimate because hashcat --keyspace exceeded keyspace_calculation_timeout_minutes.
+	NotificationTypeKeyspaceEstimateUsed   NotificationType = "keyspace_estimate_used"
 )
 
 // AllNotificationTypes returns all valid notification types
@@ -48,6 +51,7 @@ func AllNotificationTypes() []NotificationType {
 		NotificationTypeSecurityPasswordChanged,
 		NotificationTypeWebhookFailure,
 		NotificationTypeWordlistRegenFailed,
+		NotificationTypeKeyspaceEstimateUsed,
 	}
 }
 
@@ -67,7 +71,8 @@ func (t NotificationType) IsValid() bool {
 		NotificationTypeSecurityMFADisabled,
 		NotificationTypeSecurityPasswordChanged,
 		NotificationTypeWebhookFailure,
-		NotificationTypeWordlistRegenFailed:
+		NotificationTypeWordlistRegenFailed,
+		NotificationTypeKeyspaceEstimateUsed:
 		return true
 	}
 	return false

--- a/backend/internal/repository/job_execution_repository.go
+++ b/backend/internal/repository/job_execution_repository.go
@@ -685,6 +685,24 @@ func (r *JobExecutionRepository) UpdateKeyspaceInfo(ctx context.Context, job *mo
 	return nil
 }
 
+// SetBaseKeyspaceEstimated flags a job whose base_keyspace came from stored word
+// counts because the hashcat --keyspace pre-flight timed out.
+//
+// Deliberately a targeted UPDATE rather than a column on the INSERT: the flag is
+// only ever written and then read back in SQL by the dispatcher's overrun guard,
+// so keeping it out of the wide INSERT/SELECT lists avoids any risk of shifting
+// an existing scan.
+//
+// Not to be confused with is_accurate_keyspace — see the keyspaceResult doc
+// comment in services/job_execution_service.go for why they are different.
+func (r *JobExecutionRepository) SetBaseKeyspaceEstimated(ctx context.Context, id uuid.UUID, estimated bool) error {
+	query := `UPDATE job_executions SET base_keyspace_estimated = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2`
+	if _, err := r.db.ExecContext(ctx, query, estimated, id); err != nil {
+		return fmt.Errorf("failed to update job base_keyspace_estimated: %w", err)
+	}
+	return nil
+}
+
 // SetIsAccurateKeyspace updates only the is_accurate_keyspace flag for a job execution
 func (r *JobExecutionRepository) SetIsAccurateKeyspace(ctx context.Context, id uuid.UUID, isAccurate bool) error {
 	query := `UPDATE job_executions SET is_accurate_keyspace = $1, updated_at = CURRENT_TIMESTAMP WHERE id = $2`

--- a/backend/internal/services/job_execution_service.go
+++ b/backend/internal/services/job_execution_service.go
@@ -459,182 +459,33 @@ func (s *JobExecutionService) CreateJobExecution(ctx context.Context, presetJobI
 	return jobExecution, nil
 }
 
-// CreateCustomJobExecution creates a new job execution directly from custom configuration
-func (s *JobExecutionService) CreateCustomJobExecution(ctx context.Context, config CustomJobConfig, hashlistID int64, createdBy *uuid.UUID, customJobName string) (*models.JobExecution, error) {
-	debug.Log("Creating custom job execution", map[string]interface{}{
-		"name":        config.Name,
-		"hashlist_id": hashlistID,
-		"attack_mode": config.AttackMode,
-	})
-
-	// Get the hashlist
-	hashlist, err := s.hashlistRepo.GetByID(ctx, hashlistID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get hashlist: %w", err)
-	}
-
-	// Get chunk size from config or system settings
-	chunkSize := config.ChunkSizeSeconds
-	if chunkSize <= 0 {
-		// Fetch from system settings if not provided
-		defaultChunkSetting, err := s.systemSettingsRepo.GetSetting(ctx, "default_chunk_duration")
-		if err == nil && defaultChunkSetting != nil && defaultChunkSetting.Value != nil {
-			if parsed, parseErr := parseIntValueFromString(*defaultChunkSetting.Value); parseErr == nil {
-				chunkSize = parsed
-			}
-		}
-		// Final fallback
-		if chunkSize <= 0 {
-			chunkSize = 900
-		}
-	}
-
-	// Validate mask pattern for attack modes that use masks
-	if config.Mask != "" {
-		switch config.AttackMode {
-		case models.AttackModeBruteForce, models.AttackModeHybridWordlistMask, models.AttackModeHybridMaskWordlist:
-			if !validateMaskPattern(config.Mask) {
-				return nil, fmt.Errorf("invalid mask pattern format")
-			}
-		}
-	}
-
-	// Create a temporary preset job structure for keyspace calculation
-	// This ensures we use EXACTLY the same calculation logic as preset jobs
-	tempPreset := &models.PresetJob{
-		Name:                      config.Name,
-		WordlistIDs:               config.WordlistIDs,
-		RuleIDs:                   config.RuleIDs,
-		AttackMode:                config.AttackMode,
-		HashType:                  hashlist.HashTypeID,
-		BinaryVersion:             config.BinaryVersion,
-		Mask:                      config.Mask,
-		CustomCharsets:            config.CustomCharsets,
-		CustomCharsetFiles:        config.CustomCharsetFiles,
-		HexCharset:                config.HexCharset,
-		Priority:                  config.Priority,
-		MaxAgents:                 config.MaxAgents,
-		AllowHighPriorityOverride: config.AllowHighPriorityOverride,
-		ChunkSizeSeconds:          chunkSize,
-		StatusUpdatesEnabled:      true,
-		IncrementMode:             config.IncrementMode,
-		IncrementMin:              config.IncrementMin,
-		IncrementMax:              config.IncrementMax,
-	}
-
-	// Set association wordlist ID for keyspace calculation (convert UUID to string)
-	if config.AssociationWordlistID != nil {
-		assocIDStr := config.AssociationWordlistID.String()
-		tempPreset.AssociationWordlistID = &assocIDStr
-	}
-
-	// Compute keyspace + dispatch strategy (shared with the preparing/finalize path).
-	ks, err := s.computeKeyspaceStrategy(ctx, tempPreset, hashlist)
-	if err != nil {
-		return nil, err
-	}
-	totalKeyspace, effectiveKeyspace, isAccurateKeyspace := ks.base, ks.effective, ks.isAccurate
-	multiplicationFactor := ks.multiplicationFactor
-
-	// Create self-contained job execution
-	jobExecution := &models.JobExecution{
-		PresetJobID:           nil, // NULL for custom jobs
-		HashlistID:            hashlistID,
-		AssociationWordlistID: config.AssociationWordlistID, // For association attacks (-a 9)
-		Status:                models.JobExecutionStatusPending,
-		Priority:              config.Priority,
-		ProcessedKeyspace:     models.NewBigInt(0),
-		AttackMode:            config.AttackMode,
-		MaxAgents:             config.MaxAgents,
-		CreatedBy:             createdBy,
-
-		// Direct configuration (not from preset)
-		Name:                      customJobName, // Will be set with proper naming logic
-		WordlistIDs:               config.WordlistIDs,
-		RuleIDs:                   config.RuleIDs,
-		HashType:                  hashlist.HashTypeID,
-		ChunkSizeSeconds:          chunkSize,
-		StatusUpdatesEnabled:      true,
-		AllowHighPriorityOverride: config.AllowHighPriorityOverride,
-		BinaryVersion:             config.BinaryVersion,
-		Mask:                      config.Mask,
-		CustomCharsets:            config.CustomCharsets,
-		CustomCharsetFiles:        config.CustomCharsetFiles,
-		HexCharset:                config.HexCharset,
-		AdditionalArgs:            config.AdditionalArgs,
-		IncrementMode:             config.IncrementMode,
-		IncrementMin:              config.IncrementMin,
-		IncrementMax:              config.IncrementMax,
-
-		// Keyspace values from calculation
-		BaseKeyspace:         totalKeyspace,
-		EffectiveKeyspace:    effectiveKeyspace,
-		MultiplicationFactor: multiplicationFactor,
-		IsAccurateKeyspace:   isAccurateKeyspace,
-	}
-
-	err = s.jobExecRepo.Create(ctx, jobExecution)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create custom job execution: %w", err)
-	}
-
-	// Initialize increment layers if increment mode is enabled
-	// This must happen BEFORE calculateEffectiveKeyspace
-	err = s.initializeIncrementLayers(ctx, jobExecution, tempPreset)
-	if err != nil {
-		debug.Error("Failed to initialize increment layers: job_execution_id=%s, error=%v",
-			jobExecution.ID, err)
-		return nil, fmt.Errorf("failed to initialize increment layers: %w", err)
-	}
-
-	// Use the same effective keyspace calculation
-	// Skip for increment mode jobs - initializeIncrementLayers already sets both base_keyspace and effective_keyspace
-	// Skip if we already have accurate keyspace (--total-candidates succeeded)
-	// calculateEffectiveKeyspace would incorrectly overwrite base_keyspace with effective_keyspace value
-	if (jobExecution.IncrementMode == "" || jobExecution.IncrementMode == "off") && !jobExecution.IsAccurateKeyspace {
-		err = s.calculateEffectiveKeyspace(ctx, jobExecution, tempPreset)
-		if err != nil {
-			debug.Error("Failed to calculate effective keyspace: job_execution_id=%s, error=%v",
-				jobExecution.ID, err)
-			// Log the error but continue - we'll handle this in the scheduling logic
-		}
-	}
-
-	// NOTE: Rule splitting determination is DEFERRED until after forced benchmark
-	// The benchmark provides accurate effective keyspace from hashcat's progress[1]
-	// See HandleBenchmarkResult() in job_websocket_integration.go for the actual decision
-	debug.Log("Custom job execution created - rule split decision deferred to benchmark", map[string]interface{}{
-		"job_execution_id":      jobExecution.ID,
-		"base_keyspace":         totalKeyspace,
-		"effective_keyspace":    jobExecution.EffectiveKeyspace,
-		"multiplication_factor": jobExecution.MultiplicationFactor,
-	})
-
-	// Phase E hook — same as CreateJobExecution; see comment there.
-	s.populateSchedulingUnitsIfEnabled(ctx, jobExecution)
-
-	return jobExecution, nil
-}
-
 // keyspaceStrategy holds the keyspace + dispatch-strategy values computed for a
-// custom job, shared by CreateCustomJobExecution and FinalizeFilterJob (GH #40).
+// custom job, computed by FinalizeJob for a preparing row (GH #40).
 type keyspaceStrategy struct {
 	base                 *int64
 	effective            *models.BigInt
 	isAccurate           bool
 	multiplicationFactor int64
+
+	// baseEstimated is true when the hashcat --keyspace pre-flight timed out and
+	// base_keyspace came from stored word counts instead. The job is still
+	// perfectly runnable, but the operator should be told (their timeout is too
+	// low for this wordlist) and the dispatcher must not trust the tail.
+	baseEstimated    bool
+	preflightTimeout time.Duration
 }
 
 // computeKeyspaceStrategy runs hashcat keyspace calculation and derives the
 // salt-adjusted effective keyspace and (display-only) multiplication factor.
-// Extracted verbatim from the original inline block in CreateCustomJobExecution
+// Extracted from the original inline block in the synchronous custom-job creator
 // so both the synchronous and preparing/finalize paths stay consistent.
 func (s *JobExecutionService) computeKeyspaceStrategy(ctx context.Context, tempPreset *models.PresetJob, hashlist *models.HashList) (keyspaceStrategy, error) {
-	totalKeyspace, effectiveKeyspace, isAccurateKeyspace, err := s.calculateKeyspace(ctx, tempPreset, hashlist)
+	ks, err := s.calculateKeyspaceDetailed(ctx, tempPreset, hashlist)
 	if err != nil {
 		debug.Error("Failed to calculate keyspace for custom job: %v", err)
 		return keyspaceStrategy{}, fmt.Errorf("keyspace calculation is required for job execution: %w", err)
 	}
+	totalKeyspace, effectiveKeyspace, isAccurateKeyspace := ks.base, ks.effective, ks.isAccurate
 
 	// Calculate multiplication factor from keyspace values (rounded, display-only).
 	var multiplicationFactor int64 = 1
@@ -677,6 +528,8 @@ func (s *JobExecutionService) computeKeyspaceStrategy(ctx context.Context, tempP
 		effective:            effectiveKeyspace,
 		isAccurate:           isAccurateKeyspace,
 		multiplicationFactor: multiplicationFactor,
+		baseEstimated:        ks.baseEstimated,
+		preflightTimeout:     ks.preflightTimeout,
 	}, nil
 }
 
@@ -726,12 +579,13 @@ func buildTempPresetFromConfig(config CustomJobConfig, hashTypeID, chunkSize int
 	return tempPreset
 }
 
-// CreatePreparingFilterJob creates a job_executions row in the "preparing" state
-// for a custom job whose ephemeral filtered wordlist is still generating (GH #40).
-// It carries the user's chosen config (so the jobs table shows real details) but
-// no keyspace and no scheduling_units, so the scheduler ignores it. Call
-// FinalizeFilterJob once the wordlist is ready, or FailJob on error.
-func (s *JobExecutionService) CreatePreparingFilterJob(ctx context.Context, config CustomJobConfig, hashlistID int64, createdBy *uuid.UUID, name string) (*models.JobExecution, error) {
+// CreatePreparingJob creates a job_executions row in the "preparing" state for a
+// custom job whose inputs are not ready yet — either an ephemeral filtered
+// wordlist is still generating (GH #40) or the hashcat keyspace pre-flight has
+// not run. It carries the user's chosen config (so the jobs table shows real
+// details) but no keyspace and no scheduling_units, so the scheduler ignores it.
+// Call FinalizeJob once the inputs exist, or FailJob on error.
+func (s *JobExecutionService) CreatePreparingJob(ctx context.Context, config CustomJobConfig, hashlistID int64, createdBy *uuid.UUID, name string) (*models.JobExecution, error) {
 	hashlist, err := s.hashlistRepo.GetByID(ctx, hashlistID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get hashlist: %w", err)
@@ -771,11 +625,21 @@ func (s *JobExecutionService) CreatePreparingFilterJob(ctx context.Context, conf
 	return jobExecution, nil
 }
 
-// FinalizeFilterJob completes a preparing job once its filtered wordlist(s) exist:
-// config.WordlistIDs must already point at the generated (filtered) wordlists. It
-// computes keyspace, persists the swapped wordlist IDs + keyspace, creates
-// scheduling units, and flips the job to pending so the scheduler can dispatch it.
-func (s *JobExecutionService) FinalizeFilterJob(ctx context.Context, jobID uuid.UUID, config CustomJobConfig) error {
+// FinalizeJob completes a preparing job: it computes the keyspace, persists it
+// along with config.WordlistIDs, creates scheduling units, and flips the job to
+// pending so the scheduler can dispatch it.
+//
+// Two callers, both in the background:
+//   - the filtered path passes the generated (ephemeral) wordlist IDs, which
+//     replace the user's originals on the row;
+//   - the unfiltered path passes the user's own IDs, so the write is a no-op and
+//     this is purely the deferred keyspace pre-flight.
+//
+// This is where the expensive hashcat --keyspace/--total-candidates run happens
+// for a custom job. It is deliberately not on the request path: on a large
+// wordlist it can take minutes, and holding a POST open for that was what made a
+// slow keyspace look like a broken job creation.
+func (s *JobExecutionService) FinalizeJob(ctx context.Context, jobID uuid.UUID, config CustomJobConfig) error {
 	job, err := s.jobExecRepo.GetByID(ctx, jobID)
 	if err != nil {
 		return fmt.Errorf("failed to load preparing job: %w", err)
@@ -805,8 +669,16 @@ func (s *JobExecutionService) FinalizeFilterJob(ctx context.Context, jobID uuid.
 	if err := s.jobExecRepo.UpdateKeyspaceInfo(ctx, job); err != nil {
 		return fmt.Errorf("failed to update keyspace info: %w", err)
 	}
+	// Record an estimated base keyspace — must land before
+	// populateSchedulingUnitsIfEnabled below, which copies the flag onto the units.
+	if ks.baseEstimated {
+		if err := s.jobExecRepo.SetBaseKeyspaceEstimated(ctx, jobID, true); err != nil {
+			debug.Warning("Failed to flag job %s as base_keyspace_estimated: %v", jobID, err)
+		}
+		s.dispatchKeyspaceEstimateNotification(ctx, job, ks.preflightTimeout)
+	}
 
-	// Mirror CreateCustomJobExecution's post-keyspace steps.
+	// Post-keyspace steps: increment layers, effective keyspace, scheduling units.
 	if err := s.initializeIncrementLayers(ctx, job, tempPreset); err != nil {
 		return fmt.Errorf("failed to initialize increment layers: %w", err)
 	}
@@ -842,7 +714,37 @@ func (s *JobExecutionService) FailJob(ctx context.Context, jobID uuid.UUID, reas
 // Returns: baseKeyspace, effectiveKeyspace, isAccurateKeyspace, error
 // If --total-candidates succeeds, effectiveKeyspace will be accurate and isAccurateKeyspace=true
 // Otherwise, effectiveKeyspace will be an estimate and isAccurateKeyspace=false
+// keyspaceResult is the outcome of the hashcat keyspace pre-flight.
+//
+// isAccurate and baseEstimated are not the same thing and must not be conflated:
+//   - isAccurate=false means effective_keyspace is a placeholder, which is normal
+//     and self-correcting — the scheduler forces an agent benchmark and takes the
+//     real value from hashcat's progress[1].
+//   - baseEstimated=true means base_keyspace itself is an upper-bound guess from
+//     stored word counts. Nothing downstream corrects that, and base_keyspace is
+//     the coordinate space chunk ranges are expressed in, so it needs its own
+//     handling (see clampRangeToAcknowledged and the operator notification).
+type keyspaceResult struct {
+	base                   *int64
+	effective              *models.BigInt
+	isAccurate             bool
+	baseEstimated          bool
+	preflightTimeout       time.Duration
+	estimatedFromWordlists []string
+}
+
+// calculateKeyspace is the tuple-shaped wrapper kept for callers that only need
+// the three headline values. Use calculateKeyspaceDetailed when the caller has a
+// job row to annotate or an operator to notify.
 func (s *JobExecutionService) calculateKeyspace(ctx context.Context, presetJob *models.PresetJob, hashlist *models.HashList) (*int64, *models.BigInt, bool, error) {
+	res, err := s.calculateKeyspaceDetailed(ctx, presetJob, hashlist)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	return res.base, res.effective, res.isAccurate, nil
+}
+
+func (s *JobExecutionService) calculateKeyspaceDetailed(ctx context.Context, presetJob *models.PresetJob, hashlist *models.HashList) (keyspaceResult, error) {
 	debug.Log("Starting keyspace calculation for job execution", map[string]interface{}{
 		"preset_job_id":  presetJob.ID,
 		"binary_version": presetJob.BinaryVersion,
@@ -856,7 +758,7 @@ func (s *JobExecutionService) calculateKeyspace(ctx context.Context, presetJob *
 	if err != nil {
 		debug.Error("Failed to resolve binary version pattern: pattern=%s, error=%v",
 			presetJob.BinaryVersion, err)
-		return nil, nil, false, fmt.Errorf("failed to resolve binary version pattern %q: %w", presetJob.BinaryVersion, err)
+		return keyspaceResult{}, fmt.Errorf("failed to resolve binary version pattern %q: %w", presetJob.BinaryVersion, err)
 	}
 
 	// Get the hashcat binary path from binary manager
@@ -864,14 +766,14 @@ func (s *JobExecutionService) calculateKeyspace(ctx context.Context, presetJob *
 	if err != nil {
 		debug.Error("Failed to get hashcat binary path: binary_version_id=%d, error=%v",
 			binaryVersionID, err)
-		return nil, nil, false, fmt.Errorf("failed to get hashcat binary path for version %d: %w", binaryVersionID, err)
+		return keyspaceResult{}, fmt.Errorf("failed to get hashcat binary path for version %d: %w", binaryVersionID, err)
 	}
 
 	// Verify the binary exists and is executable
 	if fileInfo, err := os.Stat(hashcatPath); err != nil {
 		debug.Error("Hashcat binary not found: path=%s, error=%v",
 			hashcatPath, err)
-		return nil, nil, false, fmt.Errorf("hashcat binary not found at %s: %w", hashcatPath, err)
+		return keyspaceResult{}, fmt.Errorf("hashcat binary not found at %s: %w", hashcatPath, err)
 	} else {
 		debug.Log("Found hashcat binary", map[string]interface{}{
 			"path": hashcatPath,
@@ -896,7 +798,7 @@ func (s *JobExecutionService) calculateKeyspace(ctx context.Context, presetJob *
 		for _, wordlistIDStr := range presetJob.WordlistIDs {
 			wordlistPath, err := s.resolveWordlistPath(ctx, wordlistIDStr)
 			if err != nil {
-				return nil, nil, false, fmt.Errorf("failed to resolve wordlist path: %w", err)
+				return keyspaceResult{}, fmt.Errorf("failed to resolve wordlist path: %w", err)
 			}
 			args = append(args, wordlistPath)
 		}
@@ -904,7 +806,7 @@ func (s *JobExecutionService) calculateKeyspace(ctx context.Context, presetJob *
 		for _, ruleIDStr := range presetJob.RuleIDs {
 			rulePath, err := s.resolveRulePath(ctx, ruleIDStr)
 			if err != nil {
-				return nil, nil, false, fmt.Errorf("failed to resolve rule path: %w", err)
+				return keyspaceResult{}, fmt.Errorf("failed to resolve rule path: %w", err)
 			}
 			args = append(args, "-r", rulePath)
 		}
@@ -913,11 +815,11 @@ func (s *JobExecutionService) calculateKeyspace(ctx context.Context, presetJob *
 		if len(presetJob.WordlistIDs) >= 2 {
 			wordlist1Path, err := s.resolveWordlistPath(ctx, presetJob.WordlistIDs[0])
 			if err != nil {
-				return nil, nil, false, fmt.Errorf("failed to resolve wordlist1 path: %w", err)
+				return keyspaceResult{}, fmt.Errorf("failed to resolve wordlist1 path: %w", err)
 			}
 			wordlist2Path, err := s.resolveWordlistPath(ctx, presetJob.WordlistIDs[1])
 			if err != nil {
-				return nil, nil, false, fmt.Errorf("failed to resolve wordlist2 path: %w", err)
+				return keyspaceResult{}, fmt.Errorf("failed to resolve wordlist2 path: %w", err)
 			}
 			args = append(args, wordlist1Path, wordlist2Path)
 		}
@@ -931,7 +833,7 @@ func (s *JobExecutionService) calculateKeyspace(ctx context.Context, presetJob *
 		if len(presetJob.WordlistIDs) > 0 && presetJob.Mask != "" {
 			wordlistPath, err := s.resolveWordlistPath(ctx, presetJob.WordlistIDs[0])
 			if err != nil {
-				return nil, nil, false, fmt.Errorf("failed to resolve wordlist path: %w", err)
+				return keyspaceResult{}, fmt.Errorf("failed to resolve wordlist path: %w", err)
 			}
 			args = append(args, wordlistPath, presetJob.Mask)
 		}
@@ -940,7 +842,7 @@ func (s *JobExecutionService) calculateKeyspace(ctx context.Context, presetJob *
 		if presetJob.Mask != "" && len(presetJob.WordlistIDs) > 0 {
 			wordlistPath, err := s.resolveWordlistPath(ctx, presetJob.WordlistIDs[0])
 			if err != nil {
-				return nil, nil, false, fmt.Errorf("failed to resolve wordlist path: %w", err)
+				return keyspaceResult{}, fmt.Errorf("failed to resolve wordlist path: %w", err)
 			}
 			args = append(args, presetJob.Mask, wordlistPath)
 		}
@@ -950,13 +852,13 @@ func (s *JobExecutionService) calculateKeyspace(ctx context.Context, presetJob *
 		// Use estimation based on wordlist line count and rule count instead
 
 		if presetJob.AssociationWordlistID == nil || *presetJob.AssociationWordlistID == "" {
-			return nil, nil, false, fmt.Errorf("association wordlist ID is required for attack mode 9")
+			return keyspaceResult{}, fmt.Errorf("association wordlist ID is required for attack mode 9")
 		}
 
 		// Get wordlist line count from database
 		lineCount, err := s.getAssociationWordlistLineCount(ctx, *presetJob.AssociationWordlistID)
 		if err != nil {
-			return nil, nil, false, fmt.Errorf("failed to get association wordlist line count: %w", err)
+			return keyspaceResult{}, fmt.Errorf("failed to get association wordlist line count: %w", err)
 		}
 
 		// Get rule count for effective keyspace calculation
@@ -978,11 +880,13 @@ func (s *JobExecutionService) calculateKeyspace(ctx context.Context, presetJob *
 			"effective_keyspace":  effectiveKeyspace.String(),
 		})
 
-		// Return early - don't run hashcat --keyspace (not supported for mode 9)
-		return &baseKeyspace, &effectiveKeyspace, false, nil // false = not accurate (estimation)
+		// Return early - don't run hashcat --keyspace (not supported for mode 9).
+		// base_keyspace here is the association wordlist's stored line count, which
+		// is what mode 9 dispatches against, so it is not a fallback estimate.
+		return keyspaceResult{base: &baseKeyspace, effective: &effectiveKeyspace, isAccurate: false}, nil
 
 	default:
-		return nil, nil, false, fmt.Errorf("unsupported attack mode for keyspace calculation: %d", presetJob.AttackMode)
+		return keyspaceResult{}, fmt.Errorf("unsupported attack mode for keyspace calculation: %d", presetJob.AttackMode)
 	}
 
 	// Add --hex-charset ONLY if job uses hex mode AND has inline charset definitions
@@ -1040,13 +944,19 @@ func (s *JobExecutionService) calculateKeyspace(ctx context.Context, presetJob *
 		"session_id":  sessionID,
 	})
 
-	// Execute hashcat command with configurable timeout
+	// Execute hashcat command with configurable timeout.
+	//
+	// Deliberately scoped to its own variable rather than shadowing ctx: the
+	// --total-candidates run below must get the full configured budget, not
+	// whatever is left of this one. Shadowing meant a --keyspace call that used
+	// almost all of its deadline left --total-candidates a few seconds, so it
+	// timed out for reasons that had nothing to do with its own cost.
 	keyspaceTimeout := s.getKeyspaceTimeout(ctx)
-	ctx, cancel := context.WithTimeout(ctx, keyspaceTimeout)
+	keyspaceCtx, cancel := context.WithTimeout(ctx, keyspaceTimeout)
 	defer cancel()
 
 	startTime := time.Now()
-	cmd := exec.CommandContext(ctx, hashcatPath, args...)
+	cmd := exec.CommandContext(keyspaceCtx, hashcatPath, args...)
 
 	// Set working directory to data directory to ensure session files are created there
 	cmd.Dir = s.dataDirectory
@@ -1074,22 +984,48 @@ func (s *JobExecutionService) calculateKeyspace(ctx context.Context, presetJob *
 	}
 
 	if err != nil {
-		// Check if the error was caused by a timeout
-		if ctx.Err() == context.DeadlineExceeded {
-			debug.Error("Hashcat keyspace calculation timed out after %v", keyspaceTimeout)
-			return nil, nil, false, fmt.Errorf("keyspace calculation timed out after %v — an administrator can increase this limit in Admin Settings > Job Execution > Keyspace Calculation Timeout", keyspaceTimeout)
+		// A timeout is not a reason to refuse the job. --keyspace is a pre-flight
+		// optimisation, and for a straight attack we already know the exact word
+		// count from upload-time verification, so fall back to it and let the
+		// forced agent benchmark refine the effective keyspace as it does for any
+		// other inaccurate job. Everything else here is a genuine failure and
+		// stays fatal — a job dispatched against a wrong base keyspace is worse
+		// than a job that refuses to start.
+		if keyspaceCtx.Err() == context.DeadlineExceeded {
+			estimated, ok := s.estimateBaseKeyspace(ctx, presetJob)
+			if !ok {
+				debug.Error("Hashcat keyspace calculation timed out after %v and no base-keyspace estimate is available for attack mode %d",
+					keyspaceTimeout, presetJob.AttackMode)
+				return keyspaceResult{}, fmt.Errorf(
+					"keyspace calculation timed out after %v and attack mode %d has no fallback estimate — an administrator can increase the limit in Admin Settings > Job Execution > Keyspace Calculation Timeout",
+					keyspaceTimeout, presetJob.AttackMode)
+			}
+
+			debug.Warning("Hashcat --keyspace timed out after %v; falling back to the stored word count (%d) as an ESTIMATED base keyspace. "+
+				"The job will run with is_accurate_keyspace=false and be refined by a forced agent benchmark. "+
+				"Increase Admin Settings > Job Execution > Keyspace Calculation Timeout to avoid this.",
+				keyspaceTimeout, estimated)
+
+			return keyspaceResult{
+				base:                   &estimated,
+				effective:              s.estimateEffectiveKeyspace(ctx, estimated, presetJob),
+				isAccurate:             false,
+				baseEstimated:          true,
+				preflightTimeout:       keyspaceTimeout,
+				estimatedFromWordlists: presetJob.WordlistIDs,
+			}, nil
 		}
 		// Log the full output for debugging
 		debug.Error("Hashcat keyspace calculation failed: error=%v, stdout=%s, stderr=%s, working_dir=%s, command=%s, args=%v",
 			err, stdout.String(), stderr.String(), s.dataDirectory, hashcatPath, args)
-		return nil, nil, false, fmt.Errorf("hashcat keyspace calculation failed: %w\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+		return keyspaceResult{}, fmt.Errorf("hashcat keyspace calculation failed: %w%s", err, describeHashcatOutput(stdout.String(), stderr.String()))
 	}
 
 	// Parse keyspace from output
 	// The keyspace should be the last line of stdout (ignoring stderr warnings about invalid rules)
 	outputLines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
 	if len(outputLines) == 0 {
-		return nil, nil, false, fmt.Errorf("no output from hashcat keyspace calculation")
+		return keyspaceResult{}, fmt.Errorf("no output from hashcat keyspace calculation")
 	}
 
 	// Get the last non-empty line
@@ -1104,11 +1040,11 @@ func (s *JobExecutionService) calculateKeyspace(ctx context.Context, presetJob *
 
 	keyspace, err := strconv.ParseInt(keyspaceStr, 10, 64)
 	if err != nil {
-		return nil, nil, false, fmt.Errorf("failed to parse keyspace '%s': %w", keyspaceStr, err)
+		return keyspaceResult{}, fmt.Errorf("failed to parse keyspace '%s': %w", keyspaceStr, err)
 	}
 
 	if keyspace <= 0 {
-		return nil, nil, false, fmt.Errorf("invalid keyspace: %d", keyspace)
+		return keyspaceResult{}, fmt.Errorf("invalid keyspace: %d", keyspace)
 	}
 
 	duration := time.Since(startTime)
@@ -1166,7 +1102,82 @@ func (s *JobExecutionService) calculateKeyspace(ctx context.Context, presetJob *
 		"is_accurate_keyspace": isAccurate,
 	})
 
-	return &keyspace, effectiveKeyspacePtr, isAccurate, nil
+	return keyspaceResult{base: &keyspace, effective: effectiveKeyspacePtr, isAccurate: isAccurate}, nil
+}
+
+// describeHashcatOutput renders hashcat's captured streams for an error message.
+// Both are routinely empty because keyspace runs pass --quiet, and appending
+// "stdout: \nstderr: " to an error just buries the useful part (the exit status)
+// under two empty labels. Say so explicitly instead.
+func describeHashcatOutput(stdout, stderr string) string {
+	stdout = strings.TrimSpace(stdout)
+	stderr = strings.TrimSpace(stderr)
+	if stdout == "" && stderr == "" {
+		return " (hashcat produced no output; it runs with --quiet, so check the binary and the wordlist/rule paths)"
+	}
+	var b strings.Builder
+	if stdout != "" {
+		fmt.Fprintf(&b, "\nstdout: %s", stdout)
+	}
+	if stderr != "" {
+		fmt.Fprintf(&b, "\nstderr: %s", stderr)
+	}
+	return b.String()
+}
+
+// estimateBaseKeyspace returns a fallback base keyspace for jobs whose hashcat
+// --keyspace pre-flight timed out, and whether one could be produced.
+//
+// Only straight attacks (-a 0) qualify. There the base keyspace is the number of
+// words in the wordlist(s), which upload-time verification already counted and
+// stored (wordlists.word_count). Every other mode derives its base from hashcat's
+// own interpretation of masks/combinators, and guessing it would corrupt the
+// dispatch coordinate space — chunk ranges are expressed in base units — so those
+// modes keep failing loudly rather than running against a fabricated number.
+//
+// The result is an UPPER bound: hashcat skips words that exceed its maximum
+// password length, so its keyspace can be slightly below the raw line count.
+// Callers must therefore mark the job is_accurate_keyspace=false, and the
+// dispatcher must tolerate a short final gap (see clampRangeToAcknowledged).
+func (s *JobExecutionService) estimateBaseKeyspace(ctx context.Context, presetJob *models.PresetJob) (int64, bool) {
+	if presetJob.AttackMode != models.AttackModeStraight {
+		return 0, false
+	}
+	if len(presetJob.WordlistIDs) == 0 {
+		return 0, false
+	}
+
+	var total int64
+	for _, wordlistIDStr := range presetJob.WordlistIDs {
+		// Returns 0 for client:/potfile: refs and for anything it cannot resolve.
+		// A zero here means we do not actually know the size, so refuse rather
+		// than silently under-count the keyspace.
+		count := s.getWordlistWordCount(ctx, wordlistIDStr)
+		if count <= 0 {
+			debug.Warning("No stored word count for wordlist %q; cannot estimate base keyspace", wordlistIDStr)
+			return 0, false
+		}
+		total += count
+	}
+	return total, true
+}
+
+// estimateEffectiveKeyspace derives an effective keyspace from an estimated base
+// and the job's rule files. This is a placeholder value: the forced agent
+// benchmark replaces it with hashcat's own progress[1] before any chunk is sized,
+// which is exactly the path an is_accurate_keyspace=false job already takes.
+func (s *JobExecutionService) estimateEffectiveKeyspace(ctx context.Context, base int64, presetJob *models.PresetJob) *models.BigInt {
+	ruleCount := int64(1)
+	if len(presetJob.RuleIDs) > 0 {
+		if counted, err := s.GetTotalRuleCount(ctx, presetJob.RuleIDs); err == nil && counted > 0 {
+			ruleCount = counted
+		} else {
+			// Fall back to one rule per file — wrong, but the benchmark corrects it.
+			ruleCount = int64(len(presetJob.RuleIDs))
+		}
+	}
+	effective := models.NewBigInt(base).MulInt64(ruleCount)
+	return &effective
 }
 
 // calculateTotalCandidates runs hashcat --total-candidates with retry logic to get actual effective keyspace.
@@ -1502,7 +1513,7 @@ func (s *JobExecutionService) calculateEffectiveKeyspace(ctx context.Context, jo
 		})
 	}
 
-	// Apply salt adjustment for salted hash types (same pattern as CreateCustomJobExecution:542-567)
+	// Apply salt adjustment for salted hash types (same pattern as computeKeyspaceStrategy)
 	// calculateEffectiveKeyspace calculates base × rules, but for salted hashes we need base × rules × salts
 	if job.EffectiveKeyspace != nil && job.EffectiveKeyspace.IsPositive() {
 		hashlist, hlErr := s.hashlistRepo.GetByID(ctx, job.HashlistID)
@@ -2244,6 +2255,57 @@ func (s *JobExecutionService) dispatchJobFailedNotification(ctx context.Context,
 			"job_name":      jobExec.Name,
 			"error_message": errorMessage,
 		})
+	}
+}
+
+// dispatchKeyspaceEstimateNotification tells the operator that a job is running
+// on an estimated base keyspace because the hashcat --keyspace pre-flight timed
+// out, and names the setting to raise.
+//
+// This is informational, not a failure: the job runs normally and the forced
+// agent benchmark still supplies an accurate effective keyspace. It exists
+// because the alternative — silently running on an estimate — is how a wordlist
+// that outgrew the timeout stays invisible until someone reads the logs, and
+// with DEBUG off there are no logs to read.
+//
+// Deliberately does NOT write job_executions.error_message: that column drives
+// the failed-job UI, and this job has not failed.
+func (s *JobExecutionService) dispatchKeyspaceEstimateNotification(ctx context.Context, jobExec *models.JobExecution, timeout time.Duration) {
+	if jobExec.CreatedBy == nil {
+		return
+	}
+	dispatcher := GetGlobalDispatcher()
+	if dispatcher == nil {
+		debug.Warning("Notification dispatcher not available, skipping keyspace estimate notification")
+		return
+	}
+
+	message := fmt.Sprintf(
+		"Job '%s' is running on an estimated keyspace: hashcat --keyspace did not finish within %s, so the wordlist's stored word count was used instead. "+
+			"The job will run normally and its effective keyspace is refined by the first agent benchmark. "+
+			"To avoid this, raise Admin Settings > Job Execution > Keyspace Calculation Timeout (currently %s) — this wordlist needs longer.",
+		jobExec.Name, timeout, timeout,
+	)
+
+	params := models.NotificationDispatchParams{
+		UserID:  *jobExec.CreatedBy,
+		Type:    models.NotificationTypeKeyspaceEstimateUsed,
+		Title:   "Keyspace estimated",
+		Message: message,
+		Data: map[string]interface{}{
+			"job_id":                  jobExec.ID.String(),
+			"job_name":                jobExec.Name,
+			"keyspace_timeout":        timeout.String(),
+			"setting_key":             "keyspace_calculation_timeout_minutes",
+			"estimated_at":            time.Now().Format(time.RFC3339),
+			"estimated_base_keyspace": jobExec.BaseKeyspace,
+		},
+		SourceType: "job",
+		SourceID:   jobExec.ID.String(),
+	}
+
+	if err := dispatcher.Dispatch(ctx, params); err != nil {
+		debug.Error("Failed to dispatch keyspace estimate notification: %v", err)
 	}
 }
 

--- a/backend/internal/services/job_execution_v2.go
+++ b/backend/internal/services/job_execution_v2.go
@@ -13,7 +13,7 @@ import (
 )
 
 // populateSchedulingUnitsIfEnabled is called from CreateJobExecution /
-// CreateCustomJobExecution after the job_executions row is inserted. It
+// FinalizeJob after the job_executions row is inserted. It
 // creates the scheduling_units rows the scheduler-v2 cycle reads from.
 //
 // Errors are logged and swallowed: a partial failure means the unit
@@ -24,6 +24,22 @@ func (s *JobExecutionService) populateSchedulingUnitsIfEnabled(ctx context.Conte
 	if err := s.populateSchedulingUnits(ctx, jobExec); err != nil {
 		debug.Warning("scheduler-v2: populateSchedulingUnits for job %s failed: %v",
 			jobExec.ID, err)
+		return
+	}
+
+	// Carry base_keyspace_estimated from the job onto its unit(s). Done in SQL
+	// after the fact rather than as a denormalized struct field so it covers the
+	// single-unit and per-layer paths identically and adds nothing to the unit
+	// INSERT. Only matters for the rare job whose --keyspace pre-flight timed
+	// out; the dispatcher's overrun guard reads it to decide whether an
+	// AGENT_NO_WORK tail failure means "keyspace ended early" or a real fault.
+	if _, err := s.db.ExecContext(ctx, `
+		UPDATE scheduling_units su
+		SET base_keyspace_estimated = je.base_keyspace_estimated
+		FROM job_executions je
+		WHERE je.id = su.parent_job_id AND su.parent_job_id = $1
+	`, jobExec.ID); err != nil {
+		debug.Warning("scheduler-v2: propagate base_keyspace_estimated for job %s: %v", jobExec.ID, err)
 	}
 }
 

--- a/backend/internal/services/loopback_service.go
+++ b/backend/internal/services/loopback_service.go
@@ -296,7 +296,7 @@ func (s *LoopbackService) spawnRerun(ctx context.Context, session *models.Loopba
 	config := loopbackConfigFromJob(originJob, name)
 
 	// 1. Create the placeholder job (owns the ephemeral wordlist, ignored by scheduler).
-	prep, err := s.jobExecService.CreatePreparingFilterJob(ctx, config, session.HashlistID, creator, name)
+	prep, err := s.jobExecService.CreatePreparingJob(ctx, config, session.HashlistID, creator, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create preparing loopback job: %w", err)
 	}
@@ -311,7 +311,7 @@ func (s *LoopbackService) spawnRerun(ctx context.Context, session *models.Loopba
 
 	// 3. Swap the wordlist to the delta, compute keyspace, and open the dispatch gate.
 	config.WordlistIDs = models.IDArray{strconv.Itoa(wl.ID)}
-	if err := s.jobExecService.FinalizeFilterJob(ctx, prep.ID, config); err != nil {
+	if err := s.jobExecService.FinalizeJob(ctx, prep.ID, config); err != nil {
 		_ = s.jobExecService.FailJob(ctx, prep.ID, fmt.Sprintf("loopback: failed to finalize job: %v", err))
 		return nil, err
 	}

--- a/backend/internal/services/websocket/service.go
+++ b/backend/internal/services/websocket/service.go
@@ -1206,11 +1206,19 @@ func (s *Service) handleHashcatOutput(ctx context.Context, agent *models.Agent, 
 			return
 		}
 
-		// Log the output for debugging
+		// Relayed hashcat output, routed through the logger rather than printed
+		// directly to stdout.
+		//
+		// These were fmt.Printf, which bypassed the level gate entirely: one line
+		// per status update per running task, unconditionally. On a busy server
+		// that is the only thing in the log — it filled the 10 MB stdout.log (and
+		// so the 1-hour diagnostic capture window) with routine status JSON while
+		// real failures were being dropped by the DEBUG gate. Status goes to
+		// Debug; agent-reported errors stay visible at Warning.
 		if payload.IsError {
-			fmt.Printf("[Agent %d][Task %s][ERROR] %s\n", agent.ID, payload.TaskID, payload.Output)
+			debug.Warning("[Agent %d][Task %s] hashcat error: %s", agent.ID, payload.TaskID, payload.Output)
 		} else {
-			fmt.Printf("[Agent %d][Task %s] %s\n", agent.ID, payload.TaskID, payload.Output)
+			debug.Debug("[Agent %d][Task %s] %s", agent.ID, payload.TaskID, payload.Output)
 		}
 
 		// TODO: Store output in database or forward to interested parties via SSE

--- a/backend/pkg/debug/debug.go
+++ b/backend/pkg/debug/debug.go
@@ -132,7 +132,20 @@ func LogWithLevel(level LogLevel, format string, v ...interface{}) {
 	minLevel := currentLevel
 	mu.RUnlock()
 
-	if !enabled || level < minLevel {
+	// Warnings and errors are never gated on DEBUG — only on LOG_LEVEL.
+	//
+	// DEBUG=false used to silence every level, so a production server (the
+	// default configuration) emitted no application logs at all: a diagnostic
+	// dump from such a server contained nothing but hashcat status output, and
+	// real failures left no trace anywhere. That made LOG_LEVEL inert whenever
+	// DEBUG was off, which is the opposite of what an operator setting
+	// LOG_LEVEL=INFO expects. DEBUG now governs only the chatty levels
+	// (Debug/Info/Log); anything a human needs to see when something breaks
+	// gets through on its own.
+	if level < minLevel {
+		return
+	}
+	if !enabled && level < LevelWarning {
 		return
 	}
 

--- a/docs/admin-guide/operations/job-settings.md
+++ b/docs/admin-guide/operations/job-settings.md
@@ -81,6 +81,37 @@ Control job execution behavior and user interface settings.
 | **Max Chunk Retry Attempts** | Number of times to retry failed chunks | 3 | 0-10 | Set to 0 to disable retries |
 | **Jobs Per Page** | Default pagination size for job lists | 25 | 5-100 | Adjust based on UI preferences |
 | **Hashlist Bulk Batch Size** | Number of hashes processed per batch during import | 100,000 | 1,000-1,000,000 | Affects memory usage and import speed |
+| **Keyspace Calculation Timeout** (`keyspace_calculation_timeout_minutes`) | How long the backend may spend measuring a job's keyspace with hashcat | 4 minutes | 1-60 | Raise it for multi-gigabyte wordlists. **Not** the Speed Test timeouts — see below |
+
+#### Keyspace Calculation
+
+Before a job can be scheduled, the backend measures it by running `hashcat --keyspace` and
+`--total-candidates`, both of which read the wordlist end to end. On a multi-gigabyte list that
+takes minutes, and this setting bounds it.
+
+This runs **in the background**. Creating a job returns immediately with the job in
+`preparing`; it becomes `pending` once the measurement finishes. Users are never left waiting
+on the request, so raising this timeout costs nothing in responsiveness — it only lets a large
+wordlist finish being measured.
+
+**If the timeout is exceeded**, the job is not rejected. For a straight (`-a 0`) attack the
+backend falls back to the wordlist's stored word count, starts the job anyway, and notifies the
+user with a `keyspace_estimate_used` notification naming this setting. The job runs normally and
+its size is refined by the first agent benchmark. Attack modes whose keyspace cannot be derived
+without hashcat still fail, with a message naming this setting.
+
+Frequent `keyspace_estimate_used` notifications are the signal to raise this value.
+
+!!! warning "Three different 'timeouts' apply to a large wordlist"
+    They are easy to confuse, and two of them live on different settings pages:
+
+    | Stage | Setting | Units | Page |
+    |-------|---------|-------|------|
+    | Word count at upload | *(none — always runs to completion)* | — | — |
+    | Keyspace measurement at job creation | `keyspace_calculation_timeout_minutes` | **minutes** | Job Execution → Job Control |
+    | Agent speed test / benchmark | `speed_test_timeout_seconds_uncompressed` / `_compressed` | **seconds** | System Settings → Speed Test |
+
+    Raising the Speed Test values does **not** affect keyspace measurement, and vice versa.
 
 #### Job Interruption Behavior
 

--- a/docs/reference/architecture/benchmark-workflow.md
+++ b/docs/reference/architecture/benchmark-workflow.md
@@ -129,10 +129,41 @@ Hashcat provides the actual keyspace through `progress[1]` values, which the sys
 
 **job_executions table:**
 - `is_accurate_keyspace` (boolean): True when keyspace is from hashcat `progress[1]`
+- `base_keyspace_estimated` (boolean): True when `base_keyspace` itself is an upper-bound
+  estimate — see *Base vs effective keyspace* below
 - `avg_rule_multiplier` (float): Ratio of actual/estimated keyspace for improving future estimates
 
 **job_tasks table:**
 - `is_actual_keyspace` (boolean): True when task has actual keyspace from progress update
+
+### Base vs effective keyspace: only one of them self-heals
+
+The two keyspace values a job carries are **not** symmetric, which is why the two hashcat
+pre-flight commands are handled differently.
+
+`effective_keyspace` (from `--total-candidates`) has a fallback authority. If the command
+fails or times out, the job is created with an estimate and `is_accurate_keyspace = false`;
+the scheduler sees that, forces an agent benchmark before dispatching any chunk, and
+`HandleBenchmarkResult` replaces the estimate with hashcat's own `progress[1]`. Nothing is
+lost — this is the designed path, not an error path.
+
+`base_keyspace` (from `--keyspace`) has **no** such corrector. The benchmark never writes
+it, and it is the coordinate space chunk ranges are expressed in: `range_start`/`range_end`
+are base units and the dispatcher's tail gap runs to `scheduling_units.base_keyspace`. A
+wrong base is therefore not self-correcting — it changes what work gets dispatched.
+
+When the `--keyspace` pre-flight times out on a straight attack, the backend falls back to
+the wordlist's stored `word_count` and sets `base_keyspace_estimated`. That count is an
+**upper** bound: hashcat skips blank and over-length lines, so its keyspace can be slightly
+below the raw line count (rockyou: 14,344,384 vs 14,344,391). The final chunk can then
+address words hashcat does not index, hashcat exits 0 having tested nothing, and the agent
+reports `AGENT_NO_WORK`.
+
+`handleEstimatedKeyspaceOverrun` closes that loop: on an `AGENT_NO_WORK` failure, for a unit
+flagged `base_keyspace_estimated`, whose task range reaches the tail, it takes the failure as
+a measurement — the real keyspace ends where that task began — shrinks `base_keyspace` to
+match, clears the flag and retires the range. Outside those three conditions `AGENT_NO_WORK`
+keeps its usual meaning (a device that never ran), so this cannot mask an autotune skip.
 
 ## Hashlist Download Strategy for Benchmarks
 

--- a/docs/reference/architecture/scheduler-v2-overview.md
+++ b/docs/reference/architecture/scheduler-v2-overview.md
@@ -212,10 +212,33 @@ The scheduler reads several system settings (Admin → Settings). The most relev
 | `task_heartbeat_timeout_seconds`, `task_startup_grace_seconds`, `network_grace_seconds` | Liveness windows that decide when a running task is considered lost and gap-recovered (see [Scheduler (v2) Timing](../../admin-guide/operations/job-settings.md#scheduler-v2-timing)). |
 | `benchmark_cache_duration_hours` | How long a benchmark stays valid before re-benchmarking (default 168 = 7 days). |
 | `speed_test_timeout_seconds_uncompressed`, `speed_test_timeout_seconds_compressed` | Timeouts for an agent speed benchmark; compressed wordlists get the longer window because they must be decompressed first. (These replaced the single `speedtest_timeout_seconds`, which was deleted with the v1 scheduler.) |
-| `keyspace_calculation_timeout_minutes` | Timeout for hashcat keyspace queries on large attacks. |
+| `keyspace_calculation_timeout_minutes` | Timeout for the backend's `hashcat --keyspace` / `--total-candidates` pre-flight at job creation. **Not** the agent speed-test timeout above — see below. |
 
 See [Job Settings](../../admin-guide/operations/job-settings.md), [Job Priority](../../admin-guide/advanced/job-priority.md),
 and [Job Chunking System](../../admin-guide/advanced/chunking.md) for operator-facing detail.
+
+### Very large wordlists
+
+A multi-gigabyte wordlist is read end-to-end at three separate points, each with its
+own timeout. They are easy to confuse — all three are labelled "timeout" and two live
+on different settings pages — so when someone reports "I already raised that timeout",
+establish *which* one they changed before believing the symptom.
+
+| Stage | Runs on | Bounded by | Where in the UI |
+|-------|---------|-----------|-----------------|
+| Word count at upload | Backend, once per wordlist | none (streams the file) | — |
+| `--keyspace` / `--total-candidates` pre-flight | Backend, at job creation | `keyspace_calculation_timeout_minutes` (**minutes**) | Job Execution → Job Control |
+| Speed test / benchmark | Agent, before the first chunk | `speed_test_timeout_seconds_uncompressed` / `_compressed` (**seconds**) | System Settings → Speed Test |
+
+The pre-flight runs in the background: creating a custom job returns `202` with the job
+in `preparing`, and it flips to `pending` once the keyspace is known. A slow wordlist
+therefore delays the job becoming schedulable — it never fails the request.
+
+If `--keyspace` exceeds its timeout, the job is **not** rejected. For a straight attack
+(`-a 0`) the backend falls back to the wordlist's stored `word_count`, marks the job
+`is_accurate_keyspace = false` and `base_keyspace_estimated = true`, and notifies the
+operator (`keyspace_estimate_used`) with the setting to raise. Attack modes whose base
+keyspace cannot be derived without hashcat still fail, with a message naming the setting.
 
 ## Legacy v1 scheduler (deprecated)
 

--- a/docs/user-guide/jobs-workflows.md
+++ b/docs/user-guide/jobs-workflows.md
@@ -250,12 +250,43 @@ When a high-priority job needs immediate attention:
 ![Jobs Management Interface](../assets/images/screenshots/job_management.png)
 *The Jobs Management interface showing active password cracking jobs with status filtering (ALL, PENDING, RUNNING, COMPLETED, FAILED). The table displays job details including name, hashlist, progress, keyspace, cracked count, agents assigned, priority level, and available actions.*
 
+- **Preparing**: Job has been created but is not schedulable yet — KrakenHashes is working
+  out how much there is to crack (and generating a filtered wordlist, if you asked for one).
+  It moves to **Pending** on its own. See [What "Preparing" means](#what-preparing-means).
 - **Pending**: Job is waiting for available agents
 - **Running**: Job is actively being processed by agents
 - **Processing**: Job execution has finished but system is receiving cracked passwords from agents
 - **Completed**: Job finished successfully and all results have been processed
 - **Failed**: Job encountered an error
 - **Paused**: Job was manually paused or interrupted for a higher priority task
+
+### What "Preparing" means
+
+When you create a job, KrakenHashes first has to measure the attack — how many candidate
+passwords it will produce. For a large wordlist that means reading the whole file, which
+can take anywhere from seconds to several minutes on a multi-gigabyte list.
+
+That measurement now happens in the background. Creating a job returns immediately and the
+job appears in the table as **Preparing**; you can close the dialog and carry on. Once the
+measurement finishes the job becomes **Pending** and the scheduler picks it up normally.
+Nothing is required from you in between.
+
+!!! tip "You don't need to wait on the page"
+    Earlier versions held the create-job request open until the measurement finished, so a
+    very large wordlist could leave the dialog spinning for minutes and then fail. That no
+    longer happens — the job is already created, and it will start on its own.
+
+A job can sit in **Preparing** for a while on a very large wordlist. That is expected. If
+it turns into **Failed** instead, the job's error message says why — a filter that matched
+no words, a wordlist that no longer exists, and so on.
+
+Occasionally KrakenHashes cannot finish the exact measurement within the time your
+administrator allows, in which case it estimates the size from the wordlist's stored word
+count and starts the job anyway. You will get a notification saying so. The job runs
+normally and the size is refined automatically when an agent runs its first benchmark, so
+the only visible difference is that the estimated total may shift slightly early on. If you
+see that notification often, ask your administrator to raise **Keyspace Calculation
+Timeout** under Admin → Job Execution.
 
 ### Priority Best Practices
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -115,6 +115,24 @@ This guide helps you resolve common issues when using KrakenHashes. If your issu
   - Check attack mode parameters are valid
   - Ensure selected wordlists/rules exist
 
+**Some jobs created, others did not** (selecting several presets, or a multi-step workflow)
+- KrakenHashes now creates the ones it can and reports the rest rather than failing silently.
+  The message lists each item that did not make it and why.
+- **Solution**: act on the per-item reason — most often a preset that references a wordlist
+  or rule file that has since been deleted.
+
+### Job Stuck in Preparing
+
+A job sits in **Preparing** while KrakenHashes measures how large the attack is, which means
+reading the wordlist end to end. On a multi-gigabyte list this legitimately takes minutes.
+
+- **Normal**: it clears on its own and the job moves to Pending. Nothing to do.
+- **Still preparing after a long time**: check the job list for a **Failed** entry instead —
+  preparation failures land there with a reason rather than leaving the job stuck.
+- **Happens on every large job**: ask an administrator to raise **Keyspace Calculation
+  Timeout** (Admin → Job Execution → Job Control). Note this is a *different* setting from
+  the Speed Test timeouts under System Settings, which govern agent benchmarks.
+
 ### Job Stuck in Pending
 
 **Issue**: Job never starts

--- a/docs/user-guide/wordlist-filtering.md
+++ b/docs/user-guide/wordlist-filtering.md
@@ -50,11 +50,16 @@ When you create a **custom job**, enable the wordlist filter option, choose your
 wordlist(s), and set the criteria. On submit:
 
 1. The job is created in a **`preparing`** state while KrakenHashes generates the temporary
-   (job-scoped) filtered wordlist in the background.
-2. Once generation finishes, the job automatically moves to **`pending`** and the scheduler picks
+   (job-scoped) filtered wordlist in the background and then measures its keyspace.
+2. Once both finish, the job automatically moves to **`pending`** and the scheduler picks
    it up — no further action needed.
 3. If generation fails (for example, the filter matches zero words), the job is marked **failed**
    with the reason, and the temporary wordlist is cleaned up.
+
+!!! note "Every custom job now starts in `preparing`"
+    This is no longer specific to filtered jobs — all custom jobs are measured in the
+    background, so they all pass briefly through `preparing`. See
+    [What "Preparing" means](jobs-workflows.md#what-preparing-means).
 
 These job-scoped filtered wordlists are temporary: they belong to the job that created them and are
 not added to your general wordlist library.

--- a/frontend/src/components/hashlist/CreateJobDialog.tsx
+++ b/frontend/src/components/hashlist/CreateJobDialog.tsx
@@ -404,10 +404,26 @@ export default function CreateJobDialog({
       }
 
       const response = await api.post(`/api/hashlists/${hashlistId}/create-job`, payload);
-      
+
+      // Partial success: the backend created some jobs and could not create
+      // others (a workflow step whose preset was deleted, a keyspace failure on
+      // one preset). It still returns 201, so without this the dropped items
+      // would vanish silently — the user would see "success" and a short jobs
+      // list. Surface them and do not auto-navigate, so the message is read.
+      const failures = response.data.failures as
+        | Array<{ preset_job_id?: string; name?: string; error: string }>
+        | undefined;
+      if (failures && failures.length > 0) {
+        setError(
+          `${response.data.message}. Not created: ` +
+          failures.map((f) => `${f.name || f.preset_job_id || 'item'} — ${f.error}`).join('; ')
+        );
+        return;
+      }
+
       setLoadingMessage(response.data.message || 'Job created successfully!');
       setSuccess(true);
-      
+
       // Navigate to jobs page after a short delay
       setTimeout(() => {
         onClose();


### PR DESCRIPTION
## Problem

A ~30 GB wordlist could not be used at all. Job creation ran `hashcat --keyspace` inside the POST handler and a timeout aborted the whole request, so the user waited ~4 minutes and got an unhelpful error. Reported from a production diagnostic dump.

Root cause: `keyspace_calculation_timeout_minutes` (default **4**) is the only bound on the pre-flight, and a 31.7 GB / 2.48 B-word list cannot be scanned in that time. The same backend and binary succeed on rockyou (140 MB), so this is size, not environment. The operator had raised `speed_test_timeout_seconds_uncompressed` instead — a different stage, on a different settings page, in different units.

## The key insight: the two hashcat commands are not symmetric

- **`--total-candidates` → `effective_keyspace`** has a fallback authority. If it fails, the job carries an estimate with `is_accurate_keyspace=false`, the scheduler forces an agent benchmark, and `progress[1]` supplies the real value. Already non-fatal. **Unchanged by this PR.**
- **`--keyspace` → `base_keyspace`** has *no* corrector. The benchmark never writes it, and it is the coordinate space chunk ranges live in — `range_start`/`range_end` are base units and the dispatcher's tail gap runs to `scheduling_units.base_keyspace`.

That asymmetry is why only one of them was fatal, and it drives every decision below.

## Changes

**Creation moved off the request.** Custom jobs return `202` with the job in `preparing`, finalized in the background — reusing the existing GH #40 machinery rather than adding a second async path. The filtered-wordlist path already worked this way; the plain path was the one case that blocked.

**`--keyspace` timeout degrades instead of aborting.** For `-a 0` it falls back to the stored `word_count` with `is_accurate_keyspace=false` and `base_keyspace_estimated=true`, and notifies the user (`keyspace_estimate_used`) naming the setting to raise. Modes with no derivable base still fail, with an actionable message. Genuinely unrecoverable errors (missing binary, unresolvable wordlist) stay fatal.

**Tail guard for the estimated base.** `word_count` is an *upper* bound — hashcat skips blank and over-length lines. Verified live on this branch: hashcat returned `1,212,336,041` for a 15 GB list whose stored `word_count` is `1,212,356,404`, a **20,363-word** gap. Left unhandled, the final chunk addresses words hashcat cannot index, it exits 0 having tested nothing, and the job strands just below 100% (the #62 class). `resolveEstimatedKeyspaceOverrun` treats that as a measurement — the real keyspace ends here — shrinks `base_keyspace`, and retires the range.

**Preset/workflow errors surfaced.** Both paths discarded the error and fell through to a bare `No jobs were created` — after one full timeout *per workflow step*. Worse, partial failure returned `201` with steps silently dropped. All three creation paths now share one keyspace→400 mapping, and partial success reports what was lost.

**Logging.** `Warning`/`Error` are no longer gated on `DEBUG`. Previously `DEBUG=false` (the production default) silenced *every* level including errors, so the diagnostic dump that prompted this work contained no backend errors at all — only unconditional `fmt.Printf` agent status spam, which is now routed through `debug.Debug`.

**Also fixed along the way:** `calculateKeyspace` shadowed `ctx`, so `--total-candidates` inherited whatever was left of the `--keyspace` deadline rather than its own budget. A `--keyspace` run consuming 3m50s of a 4m budget left `--total-candidates` ten seconds.

## Testing

- `keyspace_overrun_test.go` — 7 cases. **Five assert the guard does *not* fire**: exact base keyspace, mid-keyspace failure, shrink-to-zero, unrelated errors (incl. `AGENT_AUTOTUNE`), unknown legacy tasks. `AGENT_NO_WORK` is also how an autotune-skipped device reports itself, so the dangerous failure mode here is swallowing a real fault, not missing an overrun.
- Verified end to end on a 15 GB / 1.21 B-word wordlist: async creation returns immediately, job goes `preparing` → `pending`, migrations apply cleanly.

**Not verified:** the degrade path itself never triggered in local testing — hashcat's warm dictstat cache scanned 15 GB in under the 1-minute floor, so the job completed with an accurate keyspace. The estimate → notification → benchmark-refine sequence has unit coverage but no observed end-to-end run, and neither does the tail guard (which needs a multi-day run on a keyspace that large to reach its tail).

## Notes

- Two migrations: `base_keyspace_estimated` column, `keyspace_estimate_used` notification type.
- Removes the now-unreferenced synchronous `CreateCustomJobExecution`; renames `CreatePreparingFilterJob`/`FinalizeFilterJob` to `CreatePreparingJob`/`FinalizeJob` — neither was filter-specific.
- Pre-existing and left alone: `NotificationTypeAnalyticsExport` is missing from `AllNotificationTypes()` and `IsValid()` on master, so `analytics_export` fails validation.
- No CHANGELOG entry (release-tagging only); no version bump (dedicated `chore(release)` commits).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR prevents large wordlists from blocking job creation. Custom jobs now return `202` in `preparing` while keyspace measurement runs in the background. Dictionary attacks use the stored word count when keyspace measurement times out, with safeguards for estimated keyspace overruns. The PR also improves partial-failure reporting, logging, notifications, migrations, tests, and documentation.

- **Backend**
  - Added asynchronous custom job preparation and shared `CreatePreparingJob` and `FinalizeJob` flows.
  - Added keyspace timeout fallback for straight attacks and fatal handling for unsupported modes.
  - Added estimated-keyspace tracking, notifications, and tail-overrun recovery.
  - Added per-item failure details and partial-success responses for preset and workflow creation.
  - **API/contract change:** Custom job creation returns `202` with `preparing`; failed or partial requests include detailed failure information.
  - **Database migrations:** Added `base_keyspace_estimated` columns and the `keyspace_estimate_used` notification type.
  - Warning and error logs now appear when `DEBUG` is disabled.

- **Agent**
  - Added estimated-keyspace tail handling for `AGENT_NO_WORK`.
  - Corrected scheduling ranges and parent keyspace metadata when an estimated tail is reached.
  - Separated keyspace calculation timeout handling from speed-test timeout handling.

- **Frontend**
  - Added partial-failure reporting to the job creation dialog.
  - The dialog remains open when some requested jobs fail.

- **Documentation**
  - Documented the `preparing` state, background measurement, timeout behavior, partial failures, troubleshooting, and estimated-keyspace recovery.
  - Clarified the difference between keyspace calculation and agent speed-test timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->