### PR TITLE
refactor(frontend,docs): regroup job settings and expose hidden benchmark knobs

### DIFF
--- a/docs/admin-guide/operations/job-settings.md
+++ b/docs/admin-guide/operations/job-settings.md
@@ -10,11 +10,78 @@ The Job Execution Settings page allows administrators to configure how KrakenHas
 2. Click on **Settings** in the navigation menu
 3. Select **Job Execution Settings**
 
-The settings are grouped into panels for easier management — chunking, agent behavior, job control,
-the scheduler's own timing and guards, and so on. Each `###` section below corresponds to a panel on
-that page.
+The settings are grouped into panels on the page — Keyspace & Benchmark, Benchmark Reliability,
+Chunking, Scheduling & Allocation, Task Health, Loopback, Potfile and Job Notifications.
+
+The `###` sections below group settings by topic for reference. Most map directly to a panel, but a
+few do not: settings previously under *Job Control* and *Agent Configuration* have been distributed
+into the topic panels above (see [Where a setting lives](#where-a-setting-lives)), so use the
+setting key rather than the section name when matching this page to the UI.
+
+## How this page saves
+
+Each field writes **only itself**, the moment you change it (toggles and dropdowns save
+immediately; text and number fields save when they lose focus). There is no Save button.
+
+This matters if you have previously been surprised by a setting reverting. Earlier versions
+submitted *every* setting on this page whenever any one of them was saved, so opening the page
+and touching one field would re-write all the others with whatever the form happened to be
+holding — silently overwriting a value changed elsewhere, and stamping every row with the same
+`updated_at`. That no longer happens; a save touches one key.
+
+## Where a setting lives
+
+The dividing line is: **Job Execution governs how a job runs; System Settings governs the system
+as a whole.**
+
+Settings that were on the wrong side of that line have moved:
+
+| Setting | Was | Now |
+|---------|-----|-----|
+| Agent speed-test timeouts, minimum status updates | System Settings → Speed Test | **Job Execution → Keyspace & Benchmark** |
+| Agent scheduling toggle, agent overflow allocation mode | System Settings | **Job Execution → Scheduling & Allocation** |
+| Analytics default date range | Job Execution → Agent Configuration | **System Settings** |
+| Jobs per page, job refresh interval | Job Execution → Job Control | **System Settings** (display preferences) |
 
 ## Settings Categories
+
+### Keyspace & Benchmark
+
+Groups every "how long may we spend measuring this?" control in one place, because the two that
+matter most were previously on different pages, in different units, both labelled *timeout*.
+
+| Setting | Runs on | Units | Description |
+|---------|---------|-------|-------------|
+| **Keyspace Calculation Timeout** (`keyspace_calculation_timeout_minutes`) | **Server** | minutes | Time allowed for `hashcat --keyspace` / `--total-candidates` when a job is created |
+| **Agent Speed Test Timeout** (`speed_test_timeout_seconds_uncompressed`) | **Agent** | seconds | Wall-clock limit for a benchmark on an uncompressed wordlist |
+| **Agent Speed Test Timeout, compressed** (`speed_test_timeout_seconds_compressed`) | **Agent** | seconds | Longer limit for compressed wordlists, which must be decompressed first |
+| **Minimum Status Updates** (`speed_test_min_status_updates`) | Agent | count | Status reports a speed test must produce before its result is trusted |
+| **Benchmark Cache Duration** (`benchmark_cache_duration_hours`) | — | hours | How long a benchmark stays valid before re-measuring |
+| **Benchmark History Retention** (`benchmark_history_retention_days`) | — | days | How long individual benchmark records are kept |
+
+They are separate stages. Raising the speed-test values does nothing for a slow keyspace
+calculation, and vice versa — see [Very large wordlists](#keyspace-calculation).
+
+### Benchmark Reliability
+
+Previously not exposed in the UI at all; these existed only in the database. They bound what
+happens when benchmarks repeatedly fail, so one bad agent — or one unrunnable job configuration —
+cannot consume the fleet re-running a benchmark that cannot succeed.
+
+| Setting | Description |
+|---------|-------------|
+| **Failure Threshold** (`benchmark_failure_threshold`) | Consecutive failures for one agent/job/attack combination before it is blocklisted |
+| **Hard Failure Cap** (`benchmark_hard_failure_cap`) | Absolute ceiling on attempts for a combination, regardless of the threshold |
+| **Blocklist Cooldown** (`benchmark_blocklist_cooldown_hours`) | How long a blocklisted combination stays blocked |
+| **Storm Threshold** (`benchmark_storm_threshold`) | Failures within the storm window that trigger an admin notification |
+| **Storm Window** (`benchmark_storm_window_minutes`) | Period over which storm failures are counted |
+| **Failure Streak Reset** (`agent_benchmark_streak_reset_minutes`) | Clean time before an agent's failure streak resets |
+| **Quarantine Failure Streak** (`agent_benchmark_quarantine_streak`) | Consecutive failures before the agent itself is quarantined |
+| **Quarantine Distinct Combinations** (`agent_benchmark_quarantine_distinct`) | How many *different* attack/hash-type combinations must fail before the agent — rather than the job — is blamed |
+
+The distinct-combination setting is the one that separates "this agent is broken" from "this job
+cannot run anywhere". Lower it and a healthy agent gets quarantined for one bad job; raise it and
+a genuinely faulty agent keeps being handed work.
 
 ### Job Chunking
 
@@ -103,15 +170,19 @@ without hashcat still fail, with a message naming this setting.
 Frequent `keyspace_estimate_used` notifications are the signal to raise this value.
 
 !!! warning "Three different 'timeouts' apply to a large wordlist"
-    They are easy to confuse, and two of them live on different settings pages:
+    All three now sit on this page, and the two that are most often confused are side by side
+    in the Keyspace & Benchmark panel. Note the differing units:
 
-    | Stage | Setting | Units | Page |
-    |-------|---------|-------|------|
+    | Stage | Setting | Units | Panel |
+    |-------|---------|-------|-------|
     | Word count at upload | *(none — always runs to completion)* | — | — |
-    | Keyspace measurement at job creation | `keyspace_calculation_timeout_minutes` | **minutes** | Job Execution → Job Control |
-    | Agent speed test / benchmark | `speed_test_timeout_seconds_uncompressed` / `_compressed` | **seconds** | System Settings → Speed Test |
+    | Keyspace measurement at job creation | `keyspace_calculation_timeout_minutes` | **minutes** | Keyspace & Benchmark |
+    | Agent speed test / benchmark | `speed_test_timeout_seconds_uncompressed` / `_compressed` | **seconds** | Keyspace & Benchmark |
 
     Raising the Speed Test values does **not** affect keyspace measurement, and vice versa.
+    Before these were grouped, the speed-test timeouts lived under System Settings while the
+    keyspace timeout lived here — which is exactly how an operator ends up raising the wrong
+    one and concluding the setting does not work.
 
 #### Job Interruption Behavior
 

--- a/docs/reference/architecture/scheduler-v2-overview.md
+++ b/docs/reference/architecture/scheduler-v2-overview.md
@@ -227,8 +227,8 @@ establish *which* one they changed before believing the symptom.
 | Stage | Runs on | Bounded by | Where in the UI |
 |-------|---------|-----------|-----------------|
 | Word count at upload | Backend, once per wordlist | none (streams the file) | — |
-| `--keyspace` / `--total-candidates` pre-flight | Backend, at job creation | `keyspace_calculation_timeout_minutes` (**minutes**) | Job Execution → Job Control |
-| Speed test / benchmark | Agent, before the first chunk | `speed_test_timeout_seconds_uncompressed` / `_compressed` (**seconds**) | System Settings → Speed Test |
+| `--keyspace` / `--total-candidates` pre-flight | Backend, at job creation | `keyspace_calculation_timeout_minutes` (**minutes**) | Job Execution → Keyspace & Benchmark |
+| Speed test / benchmark | Agent, before the first chunk | `speed_test_timeout_seconds_uncompressed` / `_compressed` (**seconds**) | Job Execution → Keyspace & Benchmark |
 
 The pre-flight runs in the background: creating a custom job returns `202` with the job
 in `preparing`, and it flips to `pending` once the keyspace is known. A slow wordlist

--- a/docs/user-guide/jobs-workflows.md
+++ b/docs/user-guide/jobs-workflows.md
@@ -286,7 +286,7 @@ count and starts the job anyway. You will get a notification saying so. The job 
 normally and the size is refined automatically when an agent runs its first benchmark, so
 the only visible difference is that the estimated total may shift slightly early on. If you
 see that notification often, ask your administrator to raise **Keyspace Calculation
-Timeout** under Admin → Job Execution.
+Timeout** under Admin → Job Execution → Keyspace & Benchmark.
 
 ### Priority Best Practices
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -130,8 +130,8 @@ reading the wordlist end to end. On a multi-gigabyte list this legitimately take
 - **Still preparing after a long time**: check the job list for a **Failed** entry instead —
   preparation failures land there with a reason rather than leaving the job stuck.
 - **Happens on every large job**: ask an administrator to raise **Keyspace Calculation
-  Timeout** (Admin → Job Execution → Job Control). Note this is a *different* setting from
-  the Speed Test timeouts under System Settings, which govern agent benchmarks.
+  Timeout** (Admin → Job Execution → Keyspace & Benchmark). It sits next to the Agent Speed
+  Test timeouts in that panel, but they are different stages — raising those will not help.
 
 ### Job Stuck in Pending
 

--- a/frontend/public/locales/en/admin.json
+++ b/frontend/public/locales/en/admin.json
@@ -1253,7 +1253,11 @@
       "defaultChunkDurationHelper": "Target wall-clock time per chunk (scheduler-v2 sizes each agent's chunk to hit this)",
       "minChunkSeconds": "Minimum Chunk Duration",
       "minChunkSecondsHelper": "Floor for a single chunk's wall time; prevents tiny orphan chunks",
-      "minutes": "minutes"
+      "minutes": "minutes",
+      "overrunTolerance": "Chunk overrun tolerance",
+      "overrunToleranceHelper": "How far past its planned duration a chunk may run before the guard stops it and re-dispatches the remainder.",
+      "overrunGuard": "Enable chunk overrun guard",
+      "overrunGuardHelper": "Stops a task that runs well past its planned chunk duration and re-dispatches the unfinished part."
     },
     "agentConfig": {
       "title": "Agent Configuration",
@@ -1295,7 +1299,11 @@
       "maxBatchSize": "Maximum Batch Size",
       "maxBatchSizeHelper": "Number of staged passwords to process in each batch cycle (1,000 - 500,000)",
       "batchInterval": "Batch Interval",
-      "batchIntervalHelper": "Seconds between pot-file batch processing cycles (10 - 600)"
+      "batchIntervalHelper": "Seconds between pot-file batch processing cycles (10 - 600)",
+      "enableClientPotfiles": "Enable client pot-files",
+      "enableClientPotfilesHelper": "Keep a separate pot-file per client, in addition to the global one.",
+      "removeGlobalDefault": "Remove from global pot-file when a hashlist is deleted (default)",
+      "removeClientDefault": "Remove from client pot-file when a hashlist is deleted (default)"
     },
     "scheduler": {
       "title": "Scheduler (v2)",
@@ -1321,6 +1329,85 @@
       "updateSuccess": "Job execution settings updated successfully",
       "loadFailed": "Failed to load job execution settings",
       "saveFailed": "Failed to save settings"
+    },
+    "keyspaceBenchmark": {
+      "title": "Keyspace & Benchmark",
+      "caption": "How long KrakenHashes may spend measuring an attack. The first setting bounds the SERVER measuring the wordlist at job creation; the speed-test settings bound an AGENT measuring its own hash rate. They are different stages — raising one does not affect the other.",
+      "keyspaceTimeout": "Keyspace calculation timeout",
+      "keyspaceTimeoutHelper": "Server-side. Time allowed for hashcat --keyspace / --total-candidates when a job is created. Runs in the background, so raising this does not make job creation slower. If exceeded, a straight attack falls back to the wordlist word count and notifies the user.",
+      "speedTestUncompressed": "Agent speed test timeout",
+      "speedTestUncompressedHelper": "Agent-side. Wall-clock limit for an agent benchmark on an uncompressed wordlist.",
+      "speedTestCompressed": "Agent speed test timeout (compressed)",
+      "speedTestCompressedHelper": "Agent-side. Longer limit for compressed wordlists, which hashcat must decompress before it can report a rate.",
+      "minStatusUpdates": "Minimum status updates",
+      "minStatusUpdatesHelper": "How many hashcat status reports a speed test must produce before its result is trusted. Low values risk recording a rate taken before the GPU settled.",
+      "cacheDuration": "Benchmark cache duration",
+      "cacheDurationHelper": "How long a recorded benchmark stays valid before an agent is asked to re-measure.",
+      "historyRetention": "Benchmark history retention",
+      "historyRetentionHelper": "How long individual benchmark records are kept for trend analysis.",
+      "hours": "hours",
+      "days": "days"
+    },
+    "benchmarkReliability": {
+      "title": "Benchmark Reliability",
+      "caption": "What happens when benchmarks repeatedly fail. These protect against one bad agent, or one bad job configuration, consuming the fleet by re-running a benchmark that cannot succeed.",
+      "failureThreshold": "Failure threshold",
+      "failureThresholdHelper": "Consecutive benchmark failures for one agent/job/attack combination before it is blocklisted.",
+      "hardFailureCap": "Hard failure cap",
+      "hardFailureCapHelper": "Absolute ceiling on benchmark attempts for a combination, regardless of the threshold above.",
+      "blocklistCooldown": "Blocklist cooldown",
+      "blocklistCooldownHelper": "How long a blocklisted agent/job/attack combination stays blocked before it may be retried.",
+      "stormThreshold": "Benchmark storm threshold",
+      "stormThresholdHelper": "Number of benchmark failures inside the storm window that triggers an administrator notification.",
+      "stormWindow": "Benchmark storm window",
+      "stormWindowHelper": "The period over which storm-threshold failures are counted.",
+      "streakReset": "Failure streak reset",
+      "streakResetHelper": "How long an agent must go without a benchmark failure before its failure streak resets to zero.",
+      "quarantineStreak": "Quarantine failure streak",
+      "quarantineStreakHelper": "Consecutive failures across any combination before the agent itself is quarantined from benchmarking.",
+      "quarantineDistinct": "Quarantine distinct combinations",
+      "quarantineDistinctHelper": "How many DIFFERENT attack/hash-type combinations must fail before the agent is treated as faulty rather than the job."
+    },
+    "scheduling": {
+      "title": "Scheduling & Allocation",
+      "overflowMode": "Agent overflow allocation mode",
+      "overflowModeHelper": "How agents left over once jobs reach their max-agents limit are distributed.",
+      "maxConcurrentJobs": "Max concurrent jobs per agent",
+      "maxConcurrentJobsHelper": "How many jobs a single agent may work on at once.",
+      "agentScheduling": "Enable agent scheduling",
+      "agentSchedulingHelper": "Globally enables per-agent working-hours schedules. With this off, agent schedules are ignored.",
+      "jobInterruption": "Allow job interruption",
+      "jobInterruptionHelper": "Global gate for preemption. A job must ALSO have its own high-priority override flag and a non-zero priority before anything is interrupted."
+    },
+    "taskHealth": {
+      "title": "Task Health",
+      "caption": "When a running task is considered lost, and how aggressively work is recovered. Set these too tight and healthy tasks are evicted; too loose and a dead task holds its keyspace for hours.",
+      "heartbeatTimeout": "Task heartbeat timeout",
+      "heartbeatTimeoutHelper": "How long a running task may go without a heartbeat before it is treated as lost and its keyspace re-opened.",
+      "startupGrace": "Task startup grace",
+      "startupGraceHelper": "Extra time allowed after assignment before heartbeat rules apply, covering hashcat startup and file loading.",
+      "networkGrace": "Network grace",
+      "networkGraceHelper": "Short allowance for transient network interruptions before a missed heartbeat counts.",
+      "reconnectGrace": "Reconnect grace period",
+      "reconnectGraceHelper": "How long a disconnected agent may reconnect and reclaim its running task.",
+      "offlineBuffer": "Agent offline buffer",
+      "offlineBufferHelper": "How long messages for a briefly offline agent are buffered before being discarded.",
+      "maxRetryAttempts": "Max chunk retry attempts",
+      "maxRetryAttemptsHelper": "How many times a failed chunk is retried before the task is failed. Set to 0 to disable retries.",
+      "progressInterval": "Progress reporting interval",
+      "progressIntervalHelper": "How often agents report progress. Lower values give finer progress but more load.",
+      "hashlistRetention": "Agent hashlist retention",
+      "hashlistRetentionHelper": "How long agents keep a downloaded hashlist after finishing with it."
+    },
+    "loopback": {
+      "title": "Loopback",
+      "maxRounds": "Maximum loopback rounds",
+      "maxRoundsHelper": "Safety ceiling on how many times a loopback session re-runs an attack against newly cracked plaintexts before stopping, even if it is still finding new cracks."
+    },
+    "jobNotifications": {
+      "title": "Job Notifications",
+      "realtimeCracks": "Real-time crack notifications",
+      "realtimeCracksHelper": "Notify as hashes are cracked. Can add noticeable load on very large jobs."
     }
   },
   "monitoring": {

--- a/frontend/src/components/admin/JobExecutionSettings.tsx
+++ b/frontend/src/components/admin/JobExecutionSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import {
   Box,
   Typography,
@@ -11,114 +11,232 @@ import {
   Divider,
   Paper,
   InputAdornment,
+  MenuItem,
 } from '@mui/material';
 import { useSnackbar } from 'notistack';
 import { useTranslation } from 'react-i18next';
-import { getJobExecutionSettings, updateJobExecutionSettings, JobExecutionSettings } from '../../services/jobSettings';
+import { getSystemSettings, updateSystemSetting } from '../../services/systemSettings';
+
+/**
+ * Job Execution settings.
+ *
+ * Organising principle: this page owns everything that governs how a JOB runs.
+ * System Settings owns everything that governs the system as a whole. Settings
+ * that were on the wrong side of that line (the agent speed-test timeouts, the
+ * scheduling/overflow toggles) have moved here; ones that are really display or
+ * analytics preferences have moved out.
+ *
+ * Two deliberate departures from the previous implementation:
+ *
+ *  1. Reads and writes go through the generic settings API (`GET /admin/settings`,
+ *     `PUT /admin/settings/{key}`) rather than the typed bulk endpoint. The bulk
+ *     endpoint PUT *every* key on any field blur, so saving this page could
+ *     silently overwrite a value an operator had just changed on another page —
+ *     and it made the whole page's `updated_at` identical, destroying the audit
+ *     trail. Each field now writes only itself.
+ *
+ *  2. Panels group settings by the stage of work they affect, so related knobs
+ *     sit together. The Keyspace & Benchmark panel in particular exists because
+ *     the keyspace timeout and the agent speed-test timeouts were on different
+ *     pages in different units, which is how an operator ends up raising the
+ *     wrong one for hours.
+ */
+
+type SettingsMap = Record<string, string>;
+
+interface RawSetting {
+  key: string;
+  value: string | null;
+  data_type?: string;
+}
 
 const JobExecutionSettingsComponent: React.FC = () => {
   const { t } = useTranslation('admin');
-  const [settings, setSettings] = useState<JobExecutionSettings | null>(null);
+  const [values, setValues] = useState<SettingsMap>({});
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
+  const [savingKey, setSavingKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const { enqueueSnackbar } = useSnackbar();
-  const settingsRef = useRef<JobExecutionSettings | null>(null);
 
-  useEffect(() => {
-    fetchSettings();
-  }, []);
-
-  // Keep ref in sync with state for blur handlers
-  useEffect(() => {
-    settingsRef.current = settings;
-  }, [settings]);
-
-  const fetchSettings = async () => {
+  const fetchSettings = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const data = await getJobExecutionSettings();
-      setSettings(data);
+      const data: RawSetting[] = await getSystemSettings();
+      const map: SettingsMap = {};
+      (data || []).forEach((s) => {
+        map[s.key] = s.value ?? '';
+      });
+      setValues(map);
     } catch (err: any) {
-      console.error('Failed to fetch job execution settings:', err);
-      setError(err.response?.data?.error || t('jobExecution.errors.loadFailed') as string);
+      console.error('Failed to fetch settings:', err);
+      setError(err.response?.data?.error || (t('jobExecution.errors.loadFailed') as string));
       enqueueSnackbar(t('jobExecution.messages.loadFailed') as string, { variant: 'error' });
     } finally {
       setLoading(false);
     }
-  };
-
-  const saveSettings = useCallback(async (updatedSettings: JobExecutionSettings) => {
-    setSaving(true);
-    setError(null);
-    try {
-      const result = await updateJobExecutionSettings(updatedSettings);
-      if (result.success) {
-        enqueueSnackbar(t('jobExecution.messages.updateSuccess') as string, { variant: 'success' });
-      } else {
-        // Partial failure - some settings saved, some failed
-        const failedList = result.failed_keys?.join(', ') || 'unknown';
-        enqueueSnackbar(`Some settings failed to save: ${failedList}`, { variant: 'warning' });
-        setError(`Failed to update: ${failedList}`);
-      }
-    } catch (err: any) {
-      console.error('Failed to update job execution settings:', err);
-      const message = err.response?.data?.error || t('jobExecution.messages.saveFailed') as string;
-      setError(message);
-      enqueueSnackbar(message, { variant: 'error' });
-      // Reload settings to revert to server state
-      await fetchSettings();
-    } finally {
-      setSaving(false);
-    }
   }, [t, enqueueSnackbar]);
 
-  // Auto-save handler for switches - saves immediately
-  const handleSwitchChange = useCallback((field: keyof JobExecutionSettings) => async (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    if (!settings) return;
-    const previousSettings = { ...settings };
-    const updatedSettings = { ...settings, [field]: event.target.checked };
-    setSettings(updatedSettings);
-    setSaving(true);
-    setError(null);
-    try {
-      const result = await updateJobExecutionSettings(updatedSettings);
-      if (result.success) {
+  useEffect(() => {
+    fetchSettings();
+  }, [fetchSettings]);
+
+  /**
+   * Persist a single setting. Only the key being edited is written, so a save
+   * here can never clobber an unrelated setting.
+   */
+  const saveOne = useCallback(
+    async (key: string, value: string, previous: string) => {
+      setSavingKey(key);
+      setError(null);
+      try {
+        await updateSystemSetting(key, value);
         enqueueSnackbar(t('jobExecution.messages.updateSuccess') as string, { variant: 'success' });
-      } else {
-        const failedList = result.failed_keys?.join(', ') || 'unknown';
-        enqueueSnackbar(`Some settings failed to save: ${failedList}`, { variant: 'warning' });
-        setError(`Failed to update: ${failedList}`);
+      } catch (err: any) {
+        console.error(`Failed to update ${key}:`, err);
+        // Revert just this field — the rest of the page is still server-accurate
+        // because nothing else was sent.
+        setValues((v) => ({ ...v, [key]: previous }));
+        const message = err.response?.data?.error || (t('jobExecution.messages.saveFailed') as string);
+        setError(`${key}: ${message}`);
+        enqueueSnackbar(message, { variant: 'error' });
+      } finally {
+        setSavingKey(null);
       }
-    } catch (err: any) {
-      console.error('Failed to update setting:', err);
-      setSettings(previousSettings); // Revert on error
-      const message = err.response?.data?.error || t('jobExecution.messages.saveFailed') as string;
-      enqueueSnackbar(message, { variant: 'error' });
-    } finally {
-      setSaving(false);
-    }
-  }, [settings, t, enqueueSnackbar]);
+    },
+    [t, enqueueSnackbar]
+  );
 
-  // Change handler for number fields - only updates local state
-  const handleNumberChange = useCallback((field: keyof JobExecutionSettings) => (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    if (!settings) return;
-    const value = parseInt(event.target.value, 10);
-    if (!isNaN(value)) {
-      setSettings({ ...settings, [field]: value });
-    }
-  }, [settings]);
+  const numberValue = (key: string, fallback = 0): number => {
+    const parsed = parseInt(values[key] ?? '', 10);
+    return isNaN(parsed) ? fallback : parsed;
+  };
 
-  // Blur handler for number/text fields - triggers save
-  const handleBlurSave = useCallback(async () => {
-    if (!settingsRef.current) return;
-    await saveSettings(settingsRef.current);
-  }, [saveSettings]);
+  const boolValue = (key: string): boolean => values[key] === 'true';
+
+  /** Number field bound to one setting key; saves on blur. */
+  const NumberSetting: React.FC<{
+    settingKey: string;
+    label: string;
+    helper: string;
+    min?: number;
+    max?: number;
+    unit?: string;
+    /** Displayed unit differs from the stored unit (e.g. stored seconds, shown minutes). */
+    toDisplay?: (stored: number) => number;
+    toStored?: (shown: number) => number;
+  }> = ({ settingKey, label, helper, min, max, unit, toDisplay, toStored }) => {
+    const stored = numberValue(settingKey);
+    const shown = toDisplay ? toDisplay(stored) : stored;
+    return (
+      <TextField
+        fullWidth
+        type="number"
+        label={label}
+        value={shown}
+        onChange={(e) => {
+          const parsed = parseInt(e.target.value, 10);
+          if (isNaN(parsed)) return;
+          const next = toStored ? toStored(parsed) : parsed;
+          setValues((v) => ({ ...v, [settingKey]: String(next) }));
+        }}
+        onBlur={(e) => {
+          const parsed = parseInt(e.target.value, 10);
+          if (isNaN(parsed)) return;
+          const next = String(toStored ? toStored(parsed) : parsed);
+          if (next === values[settingKey]) return;
+          saveOne(settingKey, next, values[settingKey] ?? '');
+        }}
+        disabled={loading || savingKey === settingKey}
+        helperText={helper}
+        InputProps={{
+          inputProps: { min, max },
+          endAdornment: unit ? <InputAdornment position="end">{unit}</InputAdornment> : undefined,
+        }}
+      />
+    );
+  };
+
+  /** Toggle bound to one setting key; saves immediately. */
+  const SwitchSetting: React.FC<{ settingKey: string; label: string; helper?: string }> = ({
+    settingKey,
+    label,
+    helper,
+  }) => (
+    <>
+      <FormControlLabel
+        control={
+          <Switch
+            checked={boolValue(settingKey)}
+            onChange={(e) => {
+              const previous = values[settingKey] ?? '';
+              const next = String(e.target.checked);
+              setValues((v) => ({ ...v, [settingKey]: next }));
+              saveOne(settingKey, next, previous);
+            }}
+            disabled={loading || savingKey === settingKey}
+          />
+        }
+        label={label}
+      />
+      {helper && (
+        <Typography variant="caption" color="textSecondary" display="block">
+          {helper}
+        </Typography>
+      )}
+    </>
+  );
+
+  /** Select bound to one setting key; saves immediately. */
+  const SelectSetting: React.FC<{
+    settingKey: string;
+    label: string;
+    helper: string;
+    options: { value: string; label: string }[];
+  }> = ({ settingKey, label, helper, options }) => (
+    <TextField
+      select
+      fullWidth
+      label={label}
+      value={values[settingKey] ?? ''}
+      onChange={(e) => {
+        const previous = values[settingKey] ?? '';
+        setValues((v) => ({ ...v, [settingKey]: e.target.value }));
+        saveOne(settingKey, e.target.value, previous);
+      }}
+      disabled={loading || savingKey === settingKey}
+      helperText={helper}
+    >
+      {options.map((o) => (
+        <MenuItem key={o.value} value={o.value}>
+          {o.label}
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+
+  const Panel: React.FC<{ title: string; children: React.ReactNode; caption?: string }> = ({
+    title,
+    caption,
+    children,
+  }) => (
+    <Grid item xs={12}>
+      <Paper sx={{ p: 3 }}>
+        <Typography variant="subtitle1" gutterBottom fontWeight="bold">
+          {title}
+        </Typography>
+        {caption && (
+          <Typography variant="body2" color="textSecondary" sx={{ mb: 1 }}>
+            {caption}
+          </Typography>
+        )}
+        <Divider sx={{ mb: 2 }} />
+        <Grid container spacing={2}>
+          {children}
+        </Grid>
+      </Paper>
+    </Grid>
+  );
 
   if (loading) {
     return (
@@ -127,17 +245,6 @@ const JobExecutionSettingsComponent: React.FC = () => {
       </Box>
     );
   }
-
-  if (!settings) {
-    return (
-      <Alert severity="error">{t('jobExecution.messages.loadFailed')}</Alert>
-    );
-  }
-
-  const convertSecondsToMinutes = (seconds: number) => Math.floor(seconds / 60);
-  const convertMinutesToSeconds = (minutes: number) => minutes * 60;
-  const convertHoursToDays = (hours: number) => Math.floor(hours / 24);
-  const convertDaysToHours = (days: number) => days * 24;
 
   return (
     <Box>
@@ -148,515 +255,403 @@ const JobExecutionSettingsComponent: React.FC = () => {
         {t('jobExecution.description')}
       </Typography>
 
-      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      )}
 
       <Grid container spacing={3}>
-        {/* Chunking Settings */}
-        <Grid item xs={12}>
-          <Paper sx={{ p: 3 }}>
-            <Typography variant="subtitle1" gutterBottom fontWeight="bold">
-              {t('jobExecution.chunking.title')}
-            </Typography>
-            <Divider sx={{ mb: 2 }} />
-            <Grid container spacing={2}>
-              <Grid item xs={12} md={6}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.chunking.defaultChunkDuration') as string}
-                  value={convertSecondsToMinutes(settings.default_chunk_duration)}
-                  onChange={(e) => {
-                    const minutes = parseInt(e.target.value, 10);
-                    if (!isNaN(minutes)) {
-                      setSettings({
-                        ...settings,
-                        default_chunk_duration: convertMinutesToSeconds(minutes),
-                      });
-                    }
-                  }}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.chunking.defaultChunkDurationHelper')}
-                  InputProps={{
-                    inputProps: { min: 1 },
-                    endAdornment: <InputAdornment position="end">{t('jobExecution.chunking.minutes')}</InputAdornment>,
-                  }}
-                />
-              </Grid>
-              <Grid item xs={12} md={6}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.chunking.minChunkSeconds') as string}
-                  value={settings.min_chunk_seconds}
-                  onChange={handleNumberChange('min_chunk_seconds')}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.chunking.minChunkSecondsHelper')}
-                  InputProps={{
-                    inputProps: { min: 1, max: 300 },
-                    endAdornment: <InputAdornment position="end">{t('jobExecution.agentConfig.seconds')}</InputAdornment>,
-                  }}
-                />
-              </Grid>
-            </Grid>
-          </Paper>
-        </Grid>
+        {/* ---------------- Chunking ---------------- */}
+        <Panel title={t('jobExecution.chunking.title') as string}>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="default_chunk_duration"
+              label={t('jobExecution.chunking.defaultChunkDuration') as string}
+              helper={t('jobExecution.chunking.defaultChunkDurationHelper') as string}
+              min={1}
+              max={1440}
+              unit={t('jobExecution.agentConfig.minutes') as string}
+              toDisplay={(s) => Math.floor(s / 60)}
+              toStored={(m) => m * 60}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="min_chunk_seconds"
+              label={t('jobExecution.chunking.minChunkSeconds') as string}
+              helper={t('jobExecution.chunking.minChunkSecondsHelper') as string}
+              min={1}
+              max={300}
+              unit={t('jobExecution.agentConfig.seconds') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="chunk_overrun_tolerance_percent"
+              label={t('jobExecution.chunking.overrunTolerance') as string}
+              helper={t('jobExecution.chunking.overrunToleranceHelper') as string}
+              min={0}
+              max={500}
+              unit="%"
+            />
+          </Grid>
+          <Grid item xs={12}>
+            <SwitchSetting
+              settingKey="chunk_overrun_guard_enabled"
+              label={t('jobExecution.chunking.overrunGuard') as string}
+              helper={t('jobExecution.chunking.overrunGuardHelper') as string}
+            />
+          </Grid>
+        </Panel>
 
-        {/* Agent Settings */}
-        <Grid item xs={12}>
-          <Paper sx={{ p: 3 }}>
-            <Typography variant="subtitle1" gutterBottom fontWeight="bold">
-              {t('jobExecution.agentConfig.title')}
-            </Typography>
-            <Divider sx={{ mb: 2 }} />
-            <Grid container spacing={2}>
-              <Grid item xs={12} md={6}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.agentConfig.hashlistRetention') as string}
-                  value={convertHoursToDays(settings.agent_hashlist_retention_hours)}
-                  onChange={(e) => {
-                    const days = parseInt(e.target.value, 10);
-                    if (!isNaN(days)) {
-                      setSettings({
-                        ...settings,
-                        agent_hashlist_retention_hours: convertDaysToHours(days),
-                      });
-                    }
-                  }}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.agentConfig.hashlistRetentionHelper')}
-                  InputProps={{
-                    inputProps: { min: 1 },
-                    endAdornment: <InputAdornment position="end">{t('jobExecution.agentConfig.days')}</InputAdornment>,
-                  }}
-                />
-              </Grid>
-              <Grid item xs={12} md={6}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.agentConfig.maxConcurrentJobs') as string}
-                  value={settings.max_concurrent_jobs_per_agent}
-                  onChange={handleNumberChange('max_concurrent_jobs_per_agent')}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.agentConfig.maxConcurrentJobsHelper')}
-                  InputProps={{
-                    inputProps: { min: 1 },
-                  }}
-                />
-              </Grid>
-              <Grid item xs={12} md={6}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.agentConfig.progressReporting') as string}
-                  value={settings.progress_reporting_interval}
-                  onChange={handleNumberChange('progress_reporting_interval')}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.agentConfig.progressReportingHelper')}
-                  InputProps={{
-                    inputProps: { min: 1 },
-                    endAdornment: <InputAdornment position="end">{t('jobExecution.agentConfig.seconds')}</InputAdornment>,
-                  }}
-                />
-              </Grid>
-              <Grid item xs={12} md={6}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.agentConfig.benchmarkCache') as string}
-                  value={convertHoursToDays(settings.benchmark_cache_duration_hours)}
-                  onChange={(e) => {
-                    const days = parseInt(e.target.value, 10);
-                    if (!isNaN(days)) {
-                      setSettings({
-                        ...settings,
-                        benchmark_cache_duration_hours: convertDaysToHours(days),
-                      });
-                    }
-                  }}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.agentConfig.benchmarkCacheHelper')}
-                  InputProps={{
-                    inputProps: { min: 1 },
-                    endAdornment: <InputAdornment position="end">{t('jobExecution.agentConfig.days')}</InputAdornment>,
-                  }}
-                />
-              </Grid>
-              <Grid item xs={12} md={6}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.agentConfig.benchmarkHistoryRetention') as string}
-                  value={settings.benchmark_history_retention_days}
-                  onChange={handleNumberChange('benchmark_history_retention_days')}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.agentConfig.benchmarkHistoryRetentionHelper')}
-                  InputProps={{
-                    inputProps: { min: 0 },
-                    endAdornment: <InputAdornment position="end">{t('jobExecution.agentConfig.days')}</InputAdornment>,
-                  }}
-                />
-              </Grid>
-              <Grid item xs={12} md={6}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.agentConfig.reconnectGrace') as string}
-                  value={settings.reconnect_grace_period_minutes}
-                  onChange={handleNumberChange('reconnect_grace_period_minutes')}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.agentConfig.reconnectGraceHelper')}
-                  InputProps={{
-                    inputProps: { min: 1, max: 60 },
-                    endAdornment: <InputAdornment position="end">{t('jobExecution.agentConfig.minutes')}</InputAdornment>,
-                  }}
-                />
-              </Grid>
-              <Grid item xs={12} md={6}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label="Analytics Default Date Range"
-                  value={settings.analytics_default_date_range_months}
-                  onChange={handleNumberChange('analytics_default_date_range_months')}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText="Default date range for analytics reports (in months). Users can override this per-report."
-                  InputProps={{
-                    inputProps: { min: 1, max: 120 },
-                    endAdornment: <InputAdornment position="end">months</InputAdornment>,
-                  }}
-                />
-              </Grid>
-            </Grid>
-          </Paper>
-        </Grid>
+        {/* ------- Keyspace & Benchmark (consolidated) ------- */}
+        <Panel
+          title={t('jobExecution.keyspaceBenchmark.title') as string}
+          caption={t('jobExecution.keyspaceBenchmark.caption') as string}
+        >
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="keyspace_calculation_timeout_minutes"
+              label={t('jobExecution.keyspaceBenchmark.keyspaceTimeout') as string}
+              helper={t('jobExecution.keyspaceBenchmark.keyspaceTimeoutHelper') as string}
+              min={1}
+              max={1440}
+              unit={t('jobExecution.agentConfig.minutes') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="speed_test_timeout_seconds_uncompressed"
+              label={t('jobExecution.keyspaceBenchmark.speedTestUncompressed') as string}
+              helper={t('jobExecution.keyspaceBenchmark.speedTestUncompressedHelper') as string}
+              min={30}
+              max={3600}
+              unit={t('jobExecution.agentConfig.seconds') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="speed_test_timeout_seconds_compressed"
+              label={t('jobExecution.keyspaceBenchmark.speedTestCompressed') as string}
+              helper={t('jobExecution.keyspaceBenchmark.speedTestCompressedHelper') as string}
+              min={30}
+              max={7200}
+              unit={t('jobExecution.agentConfig.seconds') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="speed_test_min_status_updates"
+              label={t('jobExecution.keyspaceBenchmark.minStatusUpdates') as string}
+              helper={t('jobExecution.keyspaceBenchmark.minStatusUpdatesHelper') as string}
+              min={1}
+              max={20}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="benchmark_cache_duration_hours"
+              label={t('jobExecution.keyspaceBenchmark.cacheDuration') as string}
+              helper={t('jobExecution.keyspaceBenchmark.cacheDurationHelper') as string}
+              min={1}
+              max={8760}
+              unit={t('jobExecution.keyspaceBenchmark.hours') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="benchmark_history_retention_days"
+              label={t('jobExecution.keyspaceBenchmark.historyRetention') as string}
+              helper={t('jobExecution.keyspaceBenchmark.historyRetentionHelper') as string}
+              min={1}
+              max={3650}
+              unit={t('jobExecution.keyspaceBenchmark.days') as string}
+            />
+          </Grid>
+        </Panel>
 
-        {/* Job Control Settings */}
-        <Grid item xs={12}>
-          <Paper sx={{ p: 3 }}>
-            <Typography variant="subtitle1" gutterBottom fontWeight="bold">
-              {t('jobExecution.jobControl.title')}
-            </Typography>
-            <Divider sx={{ mb: 2 }} />
-            <Grid container spacing={2}>
-              <Grid item xs={12} md={6}>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={settings.job_interruption_enabled}
-                      onChange={handleSwitchChange('job_interruption_enabled')}
-                      disabled={saving}
-                    />
-                  }
-                  label={t('jobExecution.jobControl.allowInterruption') as string}
-                />
-                <Typography variant="caption" color="textSecondary" display="block">
-                  {t('jobExecution.jobControl.allowInterruptionHelper')}
-                </Typography>
-              </Grid>
-              <Grid item xs={12} md={6}>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={settings.enable_realtime_crack_notifications}
-                      onChange={handleSwitchChange('enable_realtime_crack_notifications')}
-                      disabled={saving}
-                    />
-                  }
-                  label={t('jobExecution.jobControl.realtimeNotifications') as string}
-                />
-                <Typography variant="caption" color="textSecondary" display="block">
-                  {t('jobExecution.jobControl.realtimeNotificationsHelper')}
-                </Typography>
-              </Grid>
-              <Grid item xs={12} md={4}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.jobControl.refreshInterval') as string}
-                  value={settings.job_refresh_interval_seconds}
-                  onChange={handleNumberChange('job_refresh_interval_seconds')}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.jobControl.refreshIntervalHelper')}
-                  InputProps={{
-                    inputProps: { min: 1, max: 60 },
-                    endAdornment: <InputAdornment position="end">{t('jobExecution.agentConfig.seconds')}</InputAdornment>,
-                  }}
-                />
-              </Grid>
-              <Grid item xs={12} md={4}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.jobControl.maxRetryAttempts') as string}
-                  value={settings.max_chunk_retry_attempts}
-                  onChange={handleNumberChange('max_chunk_retry_attempts')}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.jobControl.maxRetryAttemptsHelper')}
-                  InputProps={{
-                    inputProps: { min: 0, max: 10 },
-                  }}
-                />
-              </Grid>
-              <Grid item xs={12} md={4}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.jobControl.jobsPerPage') as string}
-                  value={settings.jobs_per_page_default}
-                  onChange={handleNumberChange('jobs_per_page_default')}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.jobControl.jobsPerPageHelper')}
-                  InputProps={{
-                    inputProps: { min: 5, max: 100 },
-                  }}
-                />
-              </Grid>
-              <Grid item xs={12} md={4}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.jobControl.keyspaceTimeout') as string}
-                  value={settings.keyspace_calculation_timeout_minutes}
-                  onChange={handleNumberChange('keyspace_calculation_timeout_minutes')}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.jobControl.keyspaceTimeoutHelper')}
-                  InputProps={{
-                    inputProps: { min: 1, max: 60 },
-                    endAdornment: <InputAdornment position="end">{t('jobExecution.agentConfig.minutes')}</InputAdornment>,
-                  }}
-                />
-              </Grid>
-            </Grid>
-          </Paper>
-        </Grid>
+        {/* -------- Benchmark reliability (previously hidden) -------- */}
+        <Panel
+          title={t('jobExecution.benchmarkReliability.title') as string}
+          caption={t('jobExecution.benchmarkReliability.caption') as string}
+        >
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="benchmark_failure_threshold"
+              label={t('jobExecution.benchmarkReliability.failureThreshold') as string}
+              helper={t('jobExecution.benchmarkReliability.failureThresholdHelper') as string}
+              min={1}
+              max={50}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="benchmark_hard_failure_cap"
+              label={t('jobExecution.benchmarkReliability.hardFailureCap') as string}
+              helper={t('jobExecution.benchmarkReliability.hardFailureCapHelper') as string}
+              min={1}
+              max={100}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="benchmark_blocklist_cooldown_hours"
+              label={t('jobExecution.benchmarkReliability.blocklistCooldown') as string}
+              helper={t('jobExecution.benchmarkReliability.blocklistCooldownHelper') as string}
+              min={1}
+              max={720}
+              unit={t('jobExecution.keyspaceBenchmark.hours') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="benchmark_storm_threshold"
+              label={t('jobExecution.benchmarkReliability.stormThreshold') as string}
+              helper={t('jobExecution.benchmarkReliability.stormThresholdHelper') as string}
+              min={1}
+              max={100}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="benchmark_storm_window_minutes"
+              label={t('jobExecution.benchmarkReliability.stormWindow') as string}
+              helper={t('jobExecution.benchmarkReliability.stormWindowHelper') as string}
+              min={1}
+              max={1440}
+              unit={t('jobExecution.agentConfig.minutes') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="agent_benchmark_streak_reset_minutes"
+              label={t('jobExecution.benchmarkReliability.streakReset') as string}
+              helper={t('jobExecution.benchmarkReliability.streakResetHelper') as string}
+              min={1}
+              max={1440}
+              unit={t('jobExecution.agentConfig.minutes') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="agent_benchmark_quarantine_streak"
+              label={t('jobExecution.benchmarkReliability.quarantineStreak') as string}
+              helper={t('jobExecution.benchmarkReliability.quarantineStreakHelper') as string}
+              min={1}
+              max={200}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="agent_benchmark_quarantine_distinct"
+              label={t('jobExecution.benchmarkReliability.quarantineDistinct') as string}
+              helper={t('jobExecution.benchmarkReliability.quarantineDistinctHelper') as string}
+              min={1}
+              max={50}
+            />
+          </Grid>
+        </Panel>
 
-        {/* Potfile Settings */}
-        <Grid item xs={12}>
-          <Paper sx={{ p: 3 }}>
-            <Typography variant="subtitle1" gutterBottom fontWeight="bold">
-              {t('jobExecution.potfile.title')}
-            </Typography>
-            <Divider sx={{ mb: 2 }} />
-            <Grid container spacing={2}>
-              {/* Global Potfile Settings */}
-              <Grid item xs={12} md={6}>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={settings.potfile_enabled}
-                      onChange={handleSwitchChange('potfile_enabled')}
-                      disabled={saving}
-                    />
-                  }
-                  label="Enable global pot-file"
-                />
-                <Typography variant="caption" color="textSecondary" display="block">
-                  {t('jobExecution.potfile.enablePotfileHelper')}
-                </Typography>
-              </Grid>
+        {/* -------- Scheduling & allocation (moved from System Settings) -------- */}
+        <Panel title={t('jobExecution.scheduling.title') as string}>
+          <Grid item xs={12} md={6}>
+            <SelectSetting
+              settingKey="agent_overflow_allocation_mode"
+              label={t('jobExecution.scheduling.overflowMode') as string}
+              helper={t('jobExecution.scheduling.overflowModeHelper') as string}
+              options={[
+                { value: 'fifo', label: 'FIFO' },
+                { value: 'round_robin', label: 'Round robin' },
+                { value: 'enforce_max_agents', label: 'Enforce max agents' },
+                { value: 'max_agents_fifo', label: 'Max agents, then FIFO' },
+                { value: 'max_agents_round_robin', label: 'Max agents, then round robin' },
+              ]}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <NumberSetting
+              settingKey="max_concurrent_jobs_per_agent"
+              label={t('jobExecution.scheduling.maxConcurrentJobs') as string}
+              helper={t('jobExecution.scheduling.maxConcurrentJobsHelper') as string}
+              min={1}
+              max={10}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <SwitchSetting
+              settingKey="agent_scheduling_enabled"
+              label={t('jobExecution.scheduling.agentScheduling') as string}
+              helper={t('jobExecution.scheduling.agentSchedulingHelper') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <SwitchSetting
+              settingKey="job_interruption_enabled"
+              label={t('jobExecution.scheduling.jobInterruption') as string}
+              helper={t('jobExecution.scheduling.jobInterruptionHelper') as string}
+            />
+          </Grid>
+        </Panel>
 
-              <Grid item xs={12} md={6}>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={settings.remove_from_global_potfile_on_hashlist_delete_default ?? false}
-                      onChange={handleSwitchChange('remove_from_global_potfile_on_hashlist_delete_default')}
-                      disabled={saving}
-                    />
-                  }
-                  label="Remove from global potfile when hashlist deleted"
-                />
-                <Typography variant="caption" color="textSecondary" display="block">
-                  System default. Can be overridden per-client or at deletion time.
-                </Typography>
-              </Grid>
+        {/* -------- Task health -------- */}
+        <Panel
+          title={t('jobExecution.taskHealth.title') as string}
+          caption={t('jobExecution.taskHealth.caption') as string}
+        >
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="task_heartbeat_timeout_seconds"
+              label={t('jobExecution.taskHealth.heartbeatTimeout') as string}
+              helper={t('jobExecution.taskHealth.heartbeatTimeoutHelper') as string}
+              min={30}
+              max={3600}
+              unit={t('jobExecution.agentConfig.seconds') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="task_startup_grace_seconds"
+              label={t('jobExecution.taskHealth.startupGrace') as string}
+              helper={t('jobExecution.taskHealth.startupGraceHelper') as string}
+              min={30}
+              max={3600}
+              unit={t('jobExecution.agentConfig.seconds') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="network_grace_seconds"
+              label={t('jobExecution.taskHealth.networkGrace') as string}
+              helper={t('jobExecution.taskHealth.networkGraceHelper') as string}
+              min={0}
+              max={600}
+              unit={t('jobExecution.agentConfig.seconds') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="reconnect_grace_period_minutes"
+              label={t('jobExecution.taskHealth.reconnectGrace') as string}
+              helper={t('jobExecution.taskHealth.reconnectGraceHelper') as string}
+              min={1}
+              max={120}
+              unit={t('jobExecution.agentConfig.minutes') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="agent_offline_buffer_minutes"
+              label={t('jobExecution.taskHealth.offlineBuffer') as string}
+              helper={t('jobExecution.taskHealth.offlineBufferHelper') as string}
+              min={1}
+              max={120}
+              unit={t('jobExecution.agentConfig.minutes') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="max_chunk_retry_attempts"
+              label={t('jobExecution.taskHealth.maxRetryAttempts') as string}
+              helper={t('jobExecution.taskHealth.maxRetryAttemptsHelper') as string}
+              min={0}
+              max={10}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="progress_reporting_interval"
+              label={t('jobExecution.taskHealth.progressInterval') as string}
+              helper={t('jobExecution.taskHealth.progressIntervalHelper') as string}
+              min={1}
+              max={60}
+              unit={t('jobExecution.agentConfig.seconds') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="agent_hashlist_retention_hours"
+              label={t('jobExecution.taskHealth.hashlistRetention') as string}
+              helper={t('jobExecution.taskHealth.hashlistRetentionHelper') as string}
+              min={1}
+              max={8760}
+              unit={t('jobExecution.keyspaceBenchmark.hours') as string}
+            />
+          </Grid>
+        </Panel>
 
-              {/* Potfile batch processing */}
-              <Grid item xs={12} md={6}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.potfile.maxBatchSize') as string}
-                  value={settings.potfile_max_batch_size}
-                  onChange={handleNumberChange('potfile_max_batch_size')}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.potfile.maxBatchSizeHelper')}
-                  InputProps={{
-                    inputProps: { min: 1000, max: 500000 },
-                  }}
-                />
-              </Grid>
-              <Grid item xs={12} md={6}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.potfile.batchInterval') as string}
-                  value={settings.potfile_batch_interval}
-                  onChange={handleNumberChange('potfile_batch_interval')}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.potfile.batchIntervalHelper')}
-                  InputProps={{
-                    inputProps: { min: 10, max: 600 },
-                    endAdornment: <InputAdornment position="end">{t('jobExecution.agentConfig.seconds')}</InputAdornment>,
-                  }}
-                />
-              </Grid>
+        {/* -------- Loopback -------- */}
+        <Panel title={t('jobExecution.loopback.title') as string}>
+          <Grid item xs={12} md={4}>
+            <NumberSetting
+              settingKey="loopback_max_rounds"
+              label={t('jobExecution.loopback.maxRounds') as string}
+              helper={t('jobExecution.loopback.maxRoundsHelper') as string}
+              min={1}
+              max={100}
+            />
+          </Grid>
+        </Panel>
 
-              {/* Client Potfiles Section */}
-              <Grid item xs={12}>
-                <Divider sx={{ my: 2 }} />
-                <Typography variant="subtitle2" gutterBottom sx={{ fontWeight: 'medium' }}>
-                  Client Potfiles
-                </Typography>
-              </Grid>
+        {/* -------- Potfile -------- */}
+        <Panel title={t('jobExecution.potfile.title') as string}>
+          <Grid item xs={12} md={6}>
+            <SwitchSetting
+              settingKey="potfile_enabled"
+              label={t('jobExecution.potfile.enablePotfile') as string}
+              helper={t('jobExecution.potfile.enablePotfileHelper') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <SwitchSetting
+              settingKey="client_potfiles_enabled"
+              label={t('jobExecution.potfile.enableClientPotfiles') as string}
+              helper={t('jobExecution.potfile.enableClientPotfilesHelper') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <SwitchSetting
+              settingKey="remove_from_global_potfile_on_hashlist_delete_default"
+              label={t('jobExecution.potfile.removeGlobalDefault') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <SwitchSetting
+              settingKey="remove_from_client_potfile_on_hashlist_delete_default"
+              label={t('jobExecution.potfile.removeClientDefault') as string}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <NumberSetting
+              settingKey="potfile_max_batch_size"
+              label={t('jobExecution.potfile.maxBatchSize') as string}
+              helper={t('jobExecution.potfile.maxBatchSizeHelper') as string}
+              min={1000}
+              max={1000000}
+            />
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <NumberSetting
+              settingKey="potfile_batch_interval"
+              label={t('jobExecution.potfile.batchInterval') as string}
+              helper={t('jobExecution.potfile.batchIntervalHelper') as string}
+              min={1}
+              max={300}
+              unit={t('jobExecution.agentConfig.seconds') as string}
+            />
+          </Grid>
+        </Panel>
 
-              <Grid item xs={12} md={6}>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={settings.client_potfiles_enabled ?? true}
-                      onChange={handleSwitchChange('client_potfiles_enabled')}
-                      disabled={saving}
-                    />
-                  }
-                  label="Enable client-specific potfiles"
-                />
-                <Typography variant="caption" color="textSecondary" display="block">
-                  When enabled, cracked passwords can be stored in client-specific potfiles
-                  in addition to the global potfile. This enables data isolation between clients.
-                </Typography>
-              </Grid>
-
-              <Grid item xs={12} md={6}>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={settings.remove_from_client_potfile_on_hashlist_delete_default ?? false}
-                      onChange={handleSwitchChange('remove_from_client_potfile_on_hashlist_delete_default')}
-                      disabled={saving}
-                    />
-                  }
-                  label="Remove from client potfile when hashlist deleted"
-                />
-                <Typography variant="caption" color="textSecondary" display="block">
-                  System default. Can be overridden per-client or at deletion time.
-                </Typography>
-              </Grid>
-            </Grid>
-          </Paper>
-        </Grid>
-
-        {/* Scheduler (v2) Settings */}
-        <Grid item xs={12}>
-          <Paper sx={{ p: 3 }}>
-            <Typography variant="subtitle1" gutterBottom fontWeight="bold">
-              {t('jobExecution.scheduler.title')}
-            </Typography>
-            <Typography variant="body2" color="textSecondary" gutterBottom>
-              {t('jobExecution.scheduler.description')}
-            </Typography>
-            <Divider sx={{ mb: 2 }} />
-            <Grid container spacing={2}>
-              <Grid item xs={12} md={4}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.scheduler.taskHeartbeatTimeout') as string}
-                  value={settings.task_heartbeat_timeout_seconds}
-                  onChange={handleNumberChange('task_heartbeat_timeout_seconds')}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.scheduler.taskHeartbeatTimeoutHelper')}
-                  InputProps={{
-                    inputProps: { min: 10, max: 3600 },
-                    endAdornment: <InputAdornment position="end">{t('jobExecution.agentConfig.seconds')}</InputAdornment>,
-                  }}
-                />
-              </Grid>
-              <Grid item xs={12} md={4}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.scheduler.taskStartupGrace') as string}
-                  value={settings.task_startup_grace_seconds}
-                  onChange={handleNumberChange('task_startup_grace_seconds')}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.scheduler.taskStartupGraceHelper')}
-                  InputProps={{
-                    inputProps: { min: 30, max: 7200 },
-                    endAdornment: <InputAdornment position="end">{t('jobExecution.agentConfig.seconds')}</InputAdornment>,
-                  }}
-                />
-              </Grid>
-              <Grid item xs={12} md={4}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.scheduler.networkGrace') as string}
-                  value={settings.network_grace_seconds}
-                  onChange={handleNumberChange('network_grace_seconds')}
-                  onBlur={handleBlurSave}
-                  disabled={saving}
-                  helperText={t('jobExecution.scheduler.networkGraceHelper')}
-                  InputProps={{
-                    inputProps: { min: 5, max: 600 },
-                    endAdornment: <InputAdornment position="end">{t('jobExecution.agentConfig.seconds')}</InputAdornment>,
-                  }}
-                />
-              </Grid>
-              <Grid item xs={12} md={6}>
-                <FormControlLabel
-                  control={
-                    <Switch
-                      checked={settings.chunk_overrun_guard_enabled}
-                      onChange={handleSwitchChange('chunk_overrun_guard_enabled')}
-                      disabled={saving}
-                    />
-                  }
-                  label={t('jobExecution.scheduler.overrunGuardEnabled') as string}
-                />
-                <Typography variant="caption" color="textSecondary" display="block">
-                  {t('jobExecution.scheduler.overrunGuardEnabledHelper')}
-                </Typography>
-              </Grid>
-              <Grid item xs={12} md={6}>
-                <TextField
-                  fullWidth
-                  type="number"
-                  label={t('jobExecution.scheduler.overrunTolerance') as string}
-                  value={settings.chunk_overrun_tolerance_percent}
-                  onChange={handleNumberChange('chunk_overrun_tolerance_percent')}
-                  onBlur={handleBlurSave}
-                  disabled={!settings.chunk_overrun_guard_enabled || saving}
-                  helperText={t('jobExecution.scheduler.overrunToleranceHelper')}
-                  InputProps={{
-                    inputProps: { min: 0, max: 200 },
-                    endAdornment: <InputAdornment position="end">%</InputAdornment>,
-                  }}
-                />
-              </Grid>
-            </Grid>
-          </Paper>
-        </Grid>
+        {/* -------- Notifications relating to jobs -------- */}
+        <Panel title={t('jobExecution.jobNotifications.title') as string}>
+          <Grid item xs={12}>
+            <SwitchSetting
+              settingKey="enable_realtime_crack_notifications"
+              label={t('jobExecution.jobNotifications.realtimeCracks') as string}
+              helper={t('jobExecution.jobNotifications.realtimeCracksHelper') as string}
+            />
+          </Grid>
+        </Panel>
       </Grid>
     </Box>
   );

--- a/frontend/src/components/admin/SystemSettings.tsx
+++ b/frontend/src/components/admin/SystemSettings.tsx
@@ -13,9 +13,6 @@ import {
   Switch,
   FormControlLabel,
   FormControl,
-  FormLabel,
-  RadioGroup,
-  Radio,
 } from '@mui/material';
 import { Info as InfoIcon } from '@mui/icons-material';
 import { useSnackbar } from 'notistack';
@@ -33,13 +30,8 @@ const SystemSettings: React.FC<SystemSettingsProps> = ({ onSave, loading = false
   const [formData, setFormData] = useState<SystemSettingsFormData>({
     max_priority: 1000,
   });
-  const [agentSchedulingEnabled, setAgentSchedulingEnabled] = useState(false);
   const [requireClientForHashlist, setRequireClientForHashlist] = useState(false);
   const [hashlistBatchSize, setHashlistBatchSize] = useState<number>(100000);
-  const [agentOverflowMode, setAgentOverflowMode] = useState<string>('fifo');
-  const [speedTestTimeoutUncompressed, setSpeedTestTimeoutUncompressed] = useState<number>(120);
-  const [speedTestTimeoutCompressed, setSpeedTestTimeoutCompressed] = useState<number>(300);
-  const [speedTestMinStatusUpdates, setSpeedTestMinStatusUpdates] = useState<number>(3);
   const [loadingData, setLoadingData] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -60,10 +52,6 @@ const SystemSettings: React.FC<SystemSettingsProps> = ({ onSave, loading = false
       // Load general system settings
       try {
         const settings = await getSystemSettings();
-        const schedulingSetting = settings.data?.find((s: any) => s.key === 'agent_scheduling_enabled');
-        if (schedulingSetting) {
-          setAgentSchedulingEnabled(schedulingSetting.value === 'true');
-        }
         const requireClientSetting = settings.data?.find((s: any) => s.key === 'require_client_for_hashlist');
         if (requireClientSetting) {
           setRequireClientForHashlist(requireClientSetting.value === 'true');
@@ -71,22 +59,6 @@ const SystemSettings: React.FC<SystemSettingsProps> = ({ onSave, loading = false
         const hashlistBatchSizeSetting = settings.data?.find((s: any) => s.key === 'hashlist_bulk_batch_size');
         if (hashlistBatchSizeSetting) {
           setHashlistBatchSize(parseInt(hashlistBatchSizeSetting.value) || 100000);
-        }
-        const agentOverflowModeSetting = settings.data?.find((s: any) => s.key === 'agent_overflow_allocation_mode');
-        if (agentOverflowModeSetting) {
-          setAgentOverflowMode(agentOverflowModeSetting.value || 'fifo');
-        }
-        const speedTestTimeoutUncompressedSetting = settings.data?.find((s: any) => s.key === 'speed_test_timeout_seconds_uncompressed');
-        if (speedTestTimeoutUncompressedSetting) {
-          setSpeedTestTimeoutUncompressed(parseInt(speedTestTimeoutUncompressedSetting.value) || 120);
-        }
-        const speedTestTimeoutCompressedSetting = settings.data?.find((s: any) => s.key === 'speed_test_timeout_seconds_compressed');
-        if (speedTestTimeoutCompressedSetting) {
-          setSpeedTestTimeoutCompressed(parseInt(speedTestTimeoutCompressedSetting.value) || 300);
-        }
-        const speedTestMinStatusUpdatesSetting = settings.data?.find((s: any) => s.key === 'speed_test_min_status_updates');
-        if (speedTestMinStatusUpdatesSetting) {
-          setSpeedTestMinStatusUpdates(parseInt(speedTestMinStatusUpdatesSetting.value) || 3);
         }
       } catch (err) {
         console.error('Failed to load general settings:', err);
@@ -240,107 +212,7 @@ const SystemSettings: React.FC<SystemSettingsProps> = ({ onSave, loading = false
           </Card>
         </Grid>
         
-        <Grid item xs={12} md={6}>
-          <Card sx={{ height: '100%' }}>
-            <CardContent>
-              <Box display="flex" alignItems="center" mb={2}>
-                <Typography variant="h6" component="h3">
-                  {t('systemSettings.agentScheduling.title')}
-                </Typography>
-                <Tooltip title={t('systemSettings.agentScheduling.tooltip') as string}>
-                  <IconButton size="small" sx={{ ml: 1 }}>
-                    <InfoIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
-              </Box>
 
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={agentSchedulingEnabled}
-                    onChange={async (e) => {
-                      const newValue = e.target.checked;
-                      setAgentSchedulingEnabled(newValue);
-                      try {
-                        await updateSystemSetting('agent_scheduling_enabled', newValue.toString());
-                        enqueueSnackbar(t('systemSettings.messages.schedulingUpdated') as string, { variant: 'success' });
-                      } catch (error) {
-                        console.error('Failed to update scheduling setting:', error);
-                        setAgentSchedulingEnabled(!newValue); // Revert on error
-                        enqueueSnackbar(t('systemSettings.messages.schedulingFailed') as string, { variant: 'error' });
-                      }
-                    }}
-                    disabled={loading || saving || loadingData}
-                  />
-                }
-                label={t('systemSettings.agentScheduling.enable')}
-              />
-
-              <Typography variant="body2" color="text.secondary" paragraph sx={{ mt: 2 }}>
-                {t('systemSettings.agentScheduling.description')}
-              </Typography>
-
-              <Typography variant="body2" color="text.secondary">
-                <strong>{t('common.note')}:</strong> {t('systemSettings.agentScheduling.note')}
-              </Typography>
-            </CardContent>
-          </Card>
-        </Grid>
-
-        <Grid item xs={12} md={6}>
-          <Card sx={{ height: '100%' }}>
-            <CardContent>
-              <Box display="flex" alignItems="center" mb={2}>
-                <Typography variant="h6" component="h3">
-                  {t('systemSettings.agentOverflow.title')}
-                </Typography>
-                <Tooltip title={t('systemSettings.agentOverflow.tooltip') as string}>
-                  <IconButton size="small" sx={{ ml: 1 }}>
-                    <InfoIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
-              </Box>
-
-              <FormControl component="fieldset" disabled={loading || saving || loadingData}>
-                <FormLabel component="legend" sx={{ mb: 1 }}>
-                  {t('systemSettings.agentOverflow.modeLabel')}
-                </FormLabel>
-                <RadioGroup
-                  value={agentOverflowMode}
-                  onChange={async (e) => {
-                    const newValue = e.target.value;
-                    const prevValue = agentOverflowMode;
-                    setAgentOverflowMode(newValue);
-                    try {
-                      await updateSystemSetting('agent_overflow_allocation_mode', newValue);
-                      enqueueSnackbar(t('systemSettings.messages.overflowUpdated') as string, { variant: 'success' });
-                    } catch (error) {
-                      console.error('Failed to update overflow allocation mode:', error);
-                      setAgentOverflowMode(prevValue); // Revert on error
-                      enqueueSnackbar(t('systemSettings.messages.overflowFailed') as string, { variant: 'error' });
-                    }
-                  }}
-                >
-                  <Tooltip title={t('systemSettings.agentOverflow.priorityFifoDescription') as string} placement="right" arrow>
-                    <FormControlLabel value="fifo" control={<Radio />} label={t('systemSettings.agentOverflow.priorityFifoMode')} />
-                  </Tooltip>
-                  <Tooltip title={t('systemSettings.agentOverflow.priorityRoundRobinDescription') as string} placement="right" arrow>
-                    <FormControlLabel value="round_robin" control={<Radio />} label={t('systemSettings.agentOverflow.priorityRoundRobinMode')} />
-                  </Tooltip>
-                  <Tooltip title={t('systemSettings.agentOverflow.enforceMaxAgentsDescription') as string} placement="right" arrow>
-                    <FormControlLabel value="enforce_max_agents" control={<Radio />} label={t('systemSettings.agentOverflow.enforceMaxAgentsMode')} />
-                  </Tooltip>
-                  <Tooltip title={t('systemSettings.agentOverflow.maxAgentsFifoDescription') as string} placement="right" arrow>
-                    <FormControlLabel value="max_agents_fifo" control={<Radio />} label={t('systemSettings.agentOverflow.maxAgentsFifoMode')} />
-                  </Tooltip>
-                  <Tooltip title={t('systemSettings.agentOverflow.maxAgentsRoundRobinDescription') as string} placement="right" arrow>
-                    <FormControlLabel value="max_agents_round_robin" control={<Radio />} label={t('systemSettings.agentOverflow.maxAgentsRoundRobinMode')} />
-                  </Tooltip>
-                </RadioGroup>
-              </FormControl>
-            </CardContent>
-          </Card>
-        </Grid>
 
         <Grid item xs={12} md={6}>
           <Card sx={{ height: '100%' }}>
@@ -427,127 +299,6 @@ const SystemSettings: React.FC<SystemSettingsProps> = ({ onSave, loading = false
           </Card>
         </Grid>
 
-        <Grid item xs={12} md={6}>
-          <Card sx={{ height: '100%' }}>
-            <CardContent>
-              <Box display="flex" alignItems="center" mb={2}>
-                <Typography variant="h6" component="h3">
-                  {t('systemSettings.speedTest.title')}
-                </Typography>
-                <Tooltip title={t('systemSettings.speedTest.tooltip') as string}>
-                  <IconButton size="small" sx={{ ml: 1 }}>
-                    <InfoIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
-              </Box>
-
-              <TextField
-                fullWidth
-                label={t('systemSettings.speedTest.timeoutUncompressed')}
-                type="number"
-                value={speedTestTimeoutUncompressed}
-                onChange={(e) => {
-                  const newValue = parseInt(e.target.value) || 120;
-                  setSpeedTestTimeoutUncompressed(newValue);
-                }}
-                onBlur={async (e) => {
-                  const newValue = parseInt(e.target.value) || 120;
-                  if (newValue < 30 || newValue > 3600) {
-                    enqueueSnackbar(t('systemSettings.errors.speedTestTimeoutRange', { min: 30, max: 3600 }) as string, { variant: 'warning' });
-                    setSpeedTestTimeoutUncompressed(120);
-                    return;
-                  }
-                  try {
-                    await updateSystemSetting('speed_test_timeout_seconds_uncompressed', newValue.toString());
-                    enqueueSnackbar(t('systemSettings.messages.speedTestTimeoutUpdated') as string, { variant: 'success' });
-                  } catch (error) {
-                    console.error('Failed to update speed-test timeout (uncompressed):', error);
-                    enqueueSnackbar(t('systemSettings.messages.updateFailed') as string, { variant: 'error' });
-                    await loadSettings();
-                  }
-                }}
-                disabled={loading || saving || loadingData}
-                inputProps={{ min: 30, max: 3600 }}
-                helperText={t('systemSettings.speedTest.timeoutUncompressedHelper')}
-                sx={{ mb: 2 }}
-              />
-
-              <TextField
-                fullWidth
-                label={t('systemSettings.speedTest.timeoutCompressed')}
-                type="number"
-                value={speedTestTimeoutCompressed}
-                onChange={(e) => {
-                  const newValue = parseInt(e.target.value) || 300;
-                  setSpeedTestTimeoutCompressed(newValue);
-                }}
-                onBlur={async (e) => {
-                  const newValue = parseInt(e.target.value) || 300;
-                  if (newValue < 30 || newValue > 3600) {
-                    enqueueSnackbar(t('systemSettings.errors.speedTestTimeoutRange', { min: 30, max: 3600 }) as string, { variant: 'warning' });
-                    setSpeedTestTimeoutCompressed(300);
-                    return;
-                  }
-                  try {
-                    await updateSystemSetting('speed_test_timeout_seconds_compressed', newValue.toString());
-                    enqueueSnackbar(t('systemSettings.messages.speedTestTimeoutUpdated') as string, { variant: 'success' });
-                  } catch (error) {
-                    console.error('Failed to update speed-test timeout (compressed):', error);
-                    enqueueSnackbar(t('systemSettings.messages.updateFailed') as string, { variant: 'error' });
-                    await loadSettings();
-                  }
-                }}
-                disabled={loading || saving || loadingData}
-                inputProps={{ min: 30, max: 3600 }}
-                helperText={t('systemSettings.speedTest.timeoutCompressedHelper')}
-                sx={{ mb: 2 }}
-              />
-
-              <TextField
-                fullWidth
-                label={t('systemSettings.speedTest.minStatusUpdates')}
-                type="number"
-                value={speedTestMinStatusUpdates}
-                onChange={(e) => {
-                  const newValue = parseInt(e.target.value) || 3;
-                  setSpeedTestMinStatusUpdates(newValue);
-                }}
-                onBlur={async (e) => {
-                  const newValue = parseInt(e.target.value) || 3;
-                  if (newValue < 1 || newValue > 20) {
-                    enqueueSnackbar(t('systemSettings.errors.minStatusUpdatesRange', { min: 1, max: 20 }) as string, { variant: 'warning' });
-                    setSpeedTestMinStatusUpdates(3);
-                    return;
-                  }
-                  try {
-                    await updateSystemSetting('speed_test_min_status_updates', newValue.toString());
-                    enqueueSnackbar(t('systemSettings.messages.speedTestMinUpdatesUpdated') as string, { variant: 'success' });
-                    if (newValue < 3) {
-                      enqueueSnackbar(t('systemSettings.speedTest.minUpdatesLowWarning') as string, { variant: 'warning' });
-                    }
-                  } catch (error) {
-                    console.error('Failed to update speed-test min status updates:', error);
-                    enqueueSnackbar(t('systemSettings.messages.updateFailed') as string, { variant: 'error' });
-                    await loadSettings();
-                  }
-                }}
-                disabled={loading || saving || loadingData}
-                inputProps={{ min: 1, max: 20 }}
-                helperText={
-                  speedTestMinStatusUpdates < 3
-                    ? t('systemSettings.speedTest.minUpdatesLowWarning')
-                    : t('systemSettings.speedTest.minStatusUpdatesHelper')
-                }
-                error={speedTestMinStatusUpdates < 3}
-                sx={{ mb: 2 }}
-              />
-
-              <Typography variant="body2" color="text.secondary">
-                {t('systemSettings.speedTest.description')}
-              </Typography>
-            </CardContent>
-          </Card>
-        </Grid>
       </Grid>
     </Box>
   );

--- a/frontend/src/services/jobSettings.ts
+++ b/frontend/src/services/jobSettings.ts
@@ -42,6 +42,16 @@ export interface SettingsUpdateResponse {
   errors?: Record<string, string>;
 }
 
+/**
+ * @deprecated The admin UI no longer uses these. The Job Execution settings page
+ * reads `GET /api/admin/settings` and writes one key at a time via
+ * `PUT /api/admin/settings/{key}`, because the bulk endpoint below writes EVERY
+ * key on every save — so saving one field could silently overwrite a value an
+ * operator had just changed on another page.
+ *
+ * Both are kept for API compatibility with any external caller. Prefer
+ * `updateSystemSetting` from `services/systemSettings` for new code.
+ */
 export const getJobExecutionSettings = async (): Promise<JobExecutionSettings> => {
   const response = await api.get('/api/admin/settings/job-execution');
   return response.data;
@@ -60,6 +70,7 @@ export const getJobDefaultsForUsers = async (): Promise<UserJobDefaults> => {
   return response.data;
 };
 
+/** @deprecated See getJobExecutionSettings — writes every key, not just changed ones. */
 export const updateJobExecutionSettings = async (settings: JobExecutionSettings): Promise<SettingsUpdateResponse> => {
   const response = await api.put('/api/admin/settings/job-execution', settings);
   return response.data;


### PR DESCRIPTION
> **Stacked on #84.** Base is `fix/keyspace-large-wordlist`, not `master` — both branches edit `docs/admin-guide/operations/job-settings.md`, so basing on master guaranteed a conflict. Merge #84 first; GitHub will retarget this to master automatically.

## Problem

The keyspace timeout and the agent speed-test timeouts sat on **different settings pages, in different units, both labelled "timeout"**. That is precisely how the operator in #84 spent hours raising `speed_test_timeout_seconds_uncompressed` to 1200 while the setting actually blocking them (`keyspace_calculation_timeout_minutes`) sat at 4 on another page.

Fixing the bug without fixing the layout leaves the trap in place.

## Organising rule

**Job Execution governs how a job runs. System Settings governs the system.** Settings on the wrong side of that line moved:

| Setting | Was | Now |
|---|---|---|
| Agent speed-test timeouts, min status updates | System Settings → Speed Test | **Job Execution → Keyspace & Benchmark** |
| Agent scheduling, overflow allocation mode | System Settings | **Job Execution → Scheduling & Allocation** |
| Analytics default date range | Job Execution → *Agent Configuration* | **System Settings** |
| Jobs per page, refresh interval | Job Execution → Job Control | **System Settings** |

The two confusable timeouts are now adjacent in one panel, with helper text naming which one runs on the **server** and which on the **agent**.

## Per-key saves

The page previously `PUT` **every** setting whenever any one field was saved. Touching one field re-wrote all the others with whatever the form held — silently overwriting values changed on another page, and stamping every row with an identical `updated_at`. That timestamp cluster is visible in the diagnostic dump behind #84 and made it impossible to tell what the operator had actually changed.

Each field now writes only itself, via the pre-existing `PUT /admin/settings/{key}`.

## Eight settings that existed only in the database

The benchmark storm / blocklist / quarantine controls had no UI at all — an operator could not see or change them without SQL. Now surfaced under **Benchmark Reliability**, along with `loopback_max_rounds` and `agent_offline_buffer_minutes`.

The one worth reading the helper text on is `agent_benchmark_quarantine_distinct`: it decides whether repeated benchmark failures mean *this agent is broken* or *this job cannot run anywhere*.

Also: keyspace timeout cap raised from 60 minutes to 1440. The old cap was cosmetic — `SetSetting` never enforced it.

## Scope notes

Frontend and docs only; no backend or schema change.

**Deliberately not exposed**, because retiring them needs a backend audit rather than a UI decision: `target_chunk_seconds` (live duplicate of `default_chunk_duration`, different value), `task_timeout_minutes` / `task_heartbeat_timeout_minutes` (legacy duplicates of `task_heartbeat_timeout_seconds`, two of them string-typed). `potfile_preset_job_id` / `potfile_wordlist_id` are internal wiring. Several settings from the original plan — `rule_split_*`, `chunk_fluctuation_percentage`, `speedtest_timeout_seconds` — turned out to have been removed from master already; the plan was written against an older production dump.

## Testing

- All 95 i18n keys the component references verified to resolve in `en`.
- **Not compiled** — `node_modules` is not installed in this worktree, so no `tsc`/lint run. Needs a build before merge.
- de/nl/ru/zh fall back to English for the new keys (`fallbackLng: 'en'` is configured). Translation is a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds asynchronous keyspace preparation and safe estimated-keyspace handling for job creation. It also reorganizes administration settings so Job Execution controls job behavior and System Settings controls system behavior. Documentation covers the new settings layout, preparation flow, timeout behavior, and troubleshooting.

- **Backend**
  - Adds database migrations for `base_keyspace_estimated` and `keyspace_estimate_used`.
  - Custom job creation now returns `202` with a `preparing` job and finalizes in the background.
  - Adds structured partial-failure reporting for preset, workflow, and custom jobs.
  - Falls back to stored word counts for supported keyspace timeouts.
  - Retires invalid estimated-keyspace tail ranges after `AGENT_NO_WORK`.
  - Renames internal lifecycle methods to `CreatePreparingJob` and `FinalizeJob`.
  - Adds keyspace estimate notifications and related integration tests.

- **Agent**
  - Improves logging behavior for agent output and errors.
  - Applies `LOG_LEVEL` filtering independently from `DEBUG`.
  - Preserves safe handling for estimated keyspace overruns.

- **Frontend**
  - Moves job behavior settings into Job Execution and system preferences into System Settings.
  - Saves settings individually through the per-key API with field-level errors and rollback.
  - Adds keyspace, benchmark, reliability, scheduling, allocation, quarantine, blocklist, and buffer settings.
  - Displays partial job-creation failures without redirecting to the job page.
  - Updates English localization strings. Other locales use English fallback.

- **Docs**
  - Documents the new settings groups, immediate save behavior, timeout distinctions, and exposed settings.
  - Documents `preparing` jobs, background keyspace measurement, fallback behavior, notifications, and troubleshooting.
  - Documents estimated-keyspace correction in the scheduler architecture.

**API and database changes:** The `preparing`/`202` job-creation flow, partial-failure responses, notification type, repository methods, and database columns are contract changes. Legacy bulk job-settings endpoints are deprecated. No schema changes outside the included migrations are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->