### PR TITLE
fix(backend): restore keyspace-estimate handling for preset jobs

### DIFF
--- a/backend/internal/handlers/jobs/user_jobs.go
+++ b/backend/internal/handlers/jobs/user_jobs.go
@@ -722,6 +722,13 @@ type jobCreationFailure struct {
 	// Name is the preset/step name when known — more use to a human than a UUID.
 	Name  string `json:"name,omitempty"`
 	Error string `json:"error"`
+
+	// ClientError marks a failure caused by what the caller sent (a malformed ID,
+	// a reference to something that does not exist) rather than by the server
+	// failing to do its job. When every failure is one of these the response is a
+	// 400, so a bad request is not reported as a server fault. Not serialised —
+	// it only steers the status code.
+	ClientError bool `json:"-"`
 }
 
 // isKeyspaceError reports whether a job-creation error is about keyspace, and
@@ -740,9 +747,25 @@ func isKeyspaceError(err error) bool {
 	return false
 }
 
+// allClientErrors reports whether every recorded failure was caused by the
+// request itself. Used to answer 400 rather than 500 when the caller sent
+// something we could never have acted on.
+func allClientErrors(failures []jobCreationFailure) bool {
+	if len(failures) == 0 {
+		return false
+	}
+	for _, f := range failures {
+		if !f.ClientError {
+			return false
+		}
+	}
+	return true
+}
+
 // writeJobCreationFailure sends the response for a request where nothing could
 // be created. It reports the first real error instead of a generic message, and
-// maps keyspace problems to 400 so the UI can show them as actionable.
+// maps keyspace problems and bad input to 400 so the UI can show them as
+// actionable rather than as a server fault.
 func writeJobCreationFailure(w http.ResponseWriter, failures []jobCreationFailure, firstErr error) {
 	if firstErr == nil {
 		http.Error(w, "No jobs were created", http.StatusInternalServerError)
@@ -751,14 +774,18 @@ func writeJobCreationFailure(w http.ResponseWriter, failures []jobCreationFailur
 
 	status := http.StatusInternalServerError
 	prefix := "Failed to create job"
-	if isKeyspaceError(firstErr) {
+	switch {
+	case isKeyspaceError(firstErr):
 		status = http.StatusBadRequest
 		prefix = "Keyspace error"
+	case allClientErrors(failures):
+		status = http.StatusBadRequest
+		prefix = "Invalid request"
 	}
 
 	msg := fmt.Sprintf("%s: %s", prefix, firstErr.Error())
 	if len(failures) > 1 {
-		msg = fmt.Sprintf("%s (%d of %d items failed; first error shown)", msg, len(failures), len(failures))
+		msg = fmt.Sprintf("%s (and %d more; first error shown)", msg, len(failures)-1)
 	}
 	http.Error(w, msg, status)
 }
@@ -855,6 +882,11 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 			presetJobID, err := uuid.Parse(presetJobIDStr)
 			if err != nil {
 				debug.Error("Invalid preset job ID: %s", presetJobIDStr)
+				failures = append(failures, jobCreationFailure{
+					PresetJobID: presetJobIDStr,
+					Error:       fmt.Sprintf("not a valid preset job ID: %q", presetJobIDStr),
+					ClientError: true,
+				})
 				continue
 			}
 
@@ -865,6 +897,7 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 				failures = append(failures, jobCreationFailure{
 					PresetJobID: presetJobID.String(),
 					Error:       fmt.Sprintf("preset job could not be loaded: %v", err),
+					ClientError: true,
 				})
 				continue
 			}
@@ -930,8 +963,9 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 			if err != nil {
 				debug.Error("Invalid workflow ID: %s", workflowIDStr)
 				failures = append(failures, jobCreationFailure{
-					Name:  workflowIDStr,
-					Error: fmt.Sprintf("invalid workflow ID %q", workflowIDStr),
+					Name:        workflowIDStr,
+					Error:       fmt.Sprintf("invalid workflow ID %q", workflowIDStr),
+					ClientError: true,
 				})
 				continue
 			}
@@ -941,8 +975,9 @@ func (h *UserJobsHandler) CreateJobFromHashlist(w http.ResponseWriter, r *http.R
 			if err != nil {
 				debug.Error("Failed to get workflow %s: %v", workflowID, err)
 				failures = append(failures, jobCreationFailure{
-					Name:  workflowIDStr,
-					Error: fmt.Sprintf("workflow could not be loaded: %v", err),
+					Name:        workflowIDStr,
+					Error:       fmt.Sprintf("workflow could not be loaded: %v", err),
+					ClientError: true,
 				})
 				continue
 			}

--- a/backend/internal/services/job_execution_service.go
+++ b/backend/internal/services/job_execution_service.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -312,6 +313,12 @@ func (s *JobExecutionService) CreateJobExecution(ctx context.Context, presetJobI
 	var effectiveKeyspace *models.BigInt
 	var isAccurateKeyspace bool
 	var multiplicationFactor int64 = 1
+	// Set only when we fall through to a live calculation AND that calculation
+	// had to fall back to an estimate; carried down to the post-create block so
+	// the job is flagged and the operator told. A preset with a usable cached
+	// keyspace never reaches the pre-flight, so these stay zero.
+	var baseEstimated bool
+	var preflightTimeout time.Duration
 
 	if presetJob.Keyspace != nil && *presetJob.Keyspace > 0 {
 		totalKeyspace = presetJob.Keyspace
@@ -328,11 +335,13 @@ func (s *JobExecutionService) CreateJobExecution(ctx context.Context, presetJobI
 	} else {
 		// Fallback to calculating keyspace if not pre-calculated
 		debug.Warning("Preset job has no pre-calculated keyspace, calculating now")
-		totalKeyspace, effectiveKeyspace, isAccurateKeyspace, err = s.calculateKeyspace(ctx, presetJob, hashlist)
-		if err != nil {
-			debug.Error("Failed to calculate keyspace: %v", err)
-			return nil, fmt.Errorf("keyspace calculation is required for job execution: %w", err)
+		ks, ksErr := s.calculateKeyspaceDetailed(ctx, presetJob, hashlist)
+		if ksErr != nil {
+			debug.Error("Failed to calculate keyspace: %v", ksErr)
+			return nil, fmt.Errorf("keyspace calculation is required for job execution: %w", ksErr)
 		}
+		totalKeyspace, effectiveKeyspace, isAccurateKeyspace = ks.base, ks.effective, ks.isAccurate
+		baseEstimated, preflightTimeout = ks.baseEstimated, ks.preflightTimeout
 		// Calculate multiplication factor from returned values.
 		// Rounded (not truncated) so 70923768/23641330 = 2.9999… → 3, not 2.
 		// This is a display-only value; correctness paths derive the ratio from
@@ -411,6 +420,18 @@ func (s *JobExecutionService) CreateJobExecution(ctx context.Context, presetJobI
 	err = s.jobExecRepo.Create(ctx, jobExecution)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create job execution: %w", err)
+	}
+
+	// Record that base_keyspace is an upper-bound estimate and tell the operator.
+	// Mirrors CreateCustomJobExecution's handling, and must run BEFORE
+	// populateSchedulingUnitsIfEnabled below — that is what copies the flag onto
+	// the units, and without it on the unit the dispatcher's estimated-tail guard
+	// (resolveEstimatedKeyspaceOverrun) can never fire for this job.
+	if baseEstimated {
+		if err := s.jobExecRepo.SetBaseKeyspaceEstimated(ctx, jobExecution.ID, true); err != nil {
+			debug.Warning("Failed to flag job %s as base_keyspace_estimated: %v", jobExecution.ID, err)
+		}
+		s.dispatchKeyspaceEstimateNotification(ctx, jobExecution, preflightTimeout)
 	}
 
 	// Initialize increment layers if increment mode is enabled
@@ -497,7 +518,7 @@ func (s *JobExecutionService) computeKeyspaceStrategy(ctx context.Context, tempP
 	}
 
 	// For salted hash types, adjust effective_keyspace by salt count
-	// calculateKeyspace's --total-candidates = base × rules (no hashlist when run)
+	// calculateKeyspaceDetailed's --total-candidates = base × rules (no hashlist when run)
 	// Job's effective_keyspace = base × rules × salts (to match progress[1])
 	if effectiveKeyspace != nil && effectiveKeyspace.IsPositive() {
 		hashType, htErr := s.hashTypeRepo.GetByID(ctx, hashlist.HashTypeID)
@@ -710,7 +731,7 @@ func (s *JobExecutionService) FailJob(ctx context.Context, jobID uuid.UUID, reas
 	return nil
 }
 
-// calculateKeyspace calculates the total keyspace for a job using hashcat --keyspace
+// calculateKeyspaceDetailed calculates the total keyspace for a job using hashcat --keyspace
 // Returns: baseKeyspace, effectiveKeyspace, isAccurateKeyspace, error
 // If --total-candidates succeeds, effectiveKeyspace will be accurate and isAccurateKeyspace=true
 // Otherwise, effectiveKeyspace will be an estimate and isAccurateKeyspace=false
@@ -733,17 +754,15 @@ type keyspaceResult struct {
 	estimatedFromWordlists []string
 }
 
-// calculateKeyspace is the tuple-shaped wrapper kept for callers that only need
-// the three headline values. Use calculateKeyspaceDetailed when the caller has a
-// job row to annotate or an operator to notify.
-func (s *JobExecutionService) calculateKeyspace(ctx context.Context, presetJob *models.PresetJob, hashlist *models.HashList) (*int64, *models.BigInt, bool, error) {
-	res, err := s.calculateKeyspaceDetailed(ctx, presetJob, hashlist)
-	if err != nil {
-		return nil, nil, false, err
-	}
-	return res.base, res.effective, res.isAccurate, nil
-}
-
+// calculateKeyspaceDetailed is the only entry point for the keyspace pre-flight.
+//
+// There was briefly a tuple-shaped convenience wrapper around this that returned
+// (base, effective, isAccurate, error) and dropped baseEstimated/preflightTimeout.
+// It silently disabled the whole estimated-keyspace mechanism for preset jobs:
+// the fallback base was persisted without its flag, no operator notification was
+// sent, and — because the flag propagates to scheduling_units — the dispatcher's
+// tail guard could never fire. Callers take the struct so those fields cannot be
+// dropped by accident again.
 func (s *JobExecutionService) calculateKeyspaceDetailed(ctx context.Context, presetJob *models.PresetJob, hashlist *models.HashList) (keyspaceResult, error) {
 	debug.Log("Starting keyspace calculation for job execution", map[string]interface{}{
 		"preset_job_id":  presetJob.ID,
@@ -1137,8 +1156,10 @@ func describeHashcatOutput(stdout, stderr string) string {
 //
 // The result is an UPPER bound: hashcat skips words that exceed its maximum
 // password length, so its keyspace can be slightly below the raw line count.
-// Callers must therefore mark the job is_accurate_keyspace=false, and the
-// dispatcher must tolerate a short final gap (see clampRangeToAcknowledged).
+// Callers must therefore mark the job is_accurate_keyspace=false AND
+// base_keyspace_estimated=true, which is what arms resolveEstimatedKeyspaceOverrun
+// (internal/integration/job_websocket_integration.go) to retire the short final
+// gap instead of stranding the job below 100%.
 func (s *JobExecutionService) estimateBaseKeyspace(ctx context.Context, presetJob *models.PresetJob) (int64, bool) {
 	if presetJob.AttackMode != models.AttackModeStraight {
 		return 0, false
@@ -1155,6 +1176,14 @@ func (s *JobExecutionService) estimateBaseKeyspace(ctx context.Context, presetJo
 		count := s.getWordlistWordCount(ctx, wordlistIDStr)
 		if count <= 0 {
 			debug.Warning("No stored word count for wordlist %q; cannot estimate base keyspace", wordlistIDStr)
+			return 0, false
+		}
+		// Refuse rather than wrap. base_keyspace is the dispatch coordinate space,
+		// so a negative value here would not fail loudly — it would quietly produce
+		// nonsense chunk ranges. Not reachable with real wordlists (int64 max is
+		// ~9.2 quintillion words), but the check is one comparison.
+		if count > math.MaxInt64-total {
+			debug.Warning("Summed word count for the selected wordlists exceeds int64; cannot estimate base keyspace")
 			return 0, false
 		}
 		total += count
@@ -2690,7 +2719,7 @@ func (s *JobExecutionService) RepairPendingJobKeyspaces(ctx context.Context) (in
 		}
 
 		// Rebuild a preset-shaped struct from the job's own params so we reuse
-		// the exact same calculation path as creation (calculateKeyspace).
+		// the exact same calculation path as creation (calculateKeyspaceDetailed).
 		tempPreset := &models.PresetJob{
 			Name:               job.Name,
 			WordlistIDs:        job.WordlistIDs,
@@ -2704,11 +2733,15 @@ func (s *JobExecutionService) RepairPendingJobKeyspaces(ctx context.Context) (in
 			HexCharset:         job.HexCharset,
 		}
 
-		base, effective, accurate, kErr := s.calculateKeyspace(ctx, tempPreset, hashlist)
+		ks, kErr := s.calculateKeyspaceDetailed(ctx, tempPreset, hashlist)
 		if kErr != nil {
 			debug.Warning("RepairPendingJobKeyspaces: job %s keyspace calc failed: %v", job.ID, kErr)
 			continue
 		}
+		base, effective, accurate := ks.base, ks.effective, ks.isAccurate
+		// Repair only accepts an exact measurement. An estimated base is skipped
+		// rather than written, so this path never needs the baseEstimated flag —
+		// leaving the job as it is lets the agent benchmark resolve it instead.
 		if !accurate || base == nil || effective == nil || *base <= 0 || !effective.IsPositive() {
 			continue // couldn't measure accurately; leave for the agent benchmark
 		}


### PR DESCRIPTION
Follow-up to #84. Two bugs from that PR are live on master; both are on degraded/error paths, so nothing that currently succeeds is broken — but the #84 fix is only half-delivered.

Found by CodeRabbit reviewing #85 while that branch still carried #84's commits, which is why the findings read as "issues on #85" when they actually describe merged code.

## Bug 1 — the estimate mechanism was inert for preset jobs

`calculateKeyspace` was a tuple-shaped convenience wrapper I kept for two existing callers. It returned `(base, effective, isAccurate, error)` and **dropped `baseEstimated` and `preflightTimeout`**. `CreateJobExecution` — the preset path — used it.

So when a preset job's `--keyspace` timed out:

- the fallback base keyspace was persisted, but `base_keyspace_estimated` stayed `false`
- no `keyspace_estimate_used` notification fired, so the operator was never told their timeout was too low
- `populateSchedulingUnitsIfEnabled` copied `false` onto the units, so **`resolveEstimatedKeyspaceOverrun` could never fire** — the tail guard was dead for preset jobs, and they could strand just below 100% exactly as in #62

Custom jobs were unaffected: they go through `computeKeyspaceStrategy`, which already used the detailed variant.

**Fix: deleted the wrapper** rather than patching its caller. Dropping two struct fields for convenience is what caused this; leaving the convenient signature in place invites it again. Only two callers existed. `RepairPendingJobKeyspaces` takes the struct now with no behaviour change — it already skips anything not accurately measured, so it never consumes a degraded result.

## Bug 2 — malformed preset IDs still vanished

The `uuid.Parse` branch in the preset loop was the **only** remaining bare `continue` with no `failures` entry (verified against all three creation paths). A request of purely malformed IDs therefore reached the empty-result check with an empty `failures` slice and got the generic `No jobs were created` 500 — the exact response #84 set out to eliminate.

Now recorded per item. Failures caused by the request rather than the server are tagged, and when *all* failures are client errors the response is **400** instead of 500.

## Bug 3 — overflow guard

`estimateBaseKeyspace` summed word counts with no overflow check. Not reachable with real wordlists (int64 max ≈ 9.2 quintillion words), but a wrapped negative `base_keyspace` would not fail loudly — it would quietly produce nonsense chunk ranges, since base is the dispatch coordinate space. One comparison.

## Deliberately not in scope

- **Repository-boundary violations** (raw `*sql.DB`/`BeginTx` in `job_websocket_integration.go`, `job_execution_v2.go`). A real CLAUDE.md breach, but fixing it properly means new `SchedulingUnitRepository` methods and threading `db.Begin()` — a refactor that would drown these two fixes.
- **Reversible enum down-migration.** Postgres cannot drop an enum value without recreating the type and rewriting every dependent column; every enum migration in this repo, including `analytics_export`, ships a documented no-op down. Changing that is a project-wide convention decision.

## Testing

Two files, no schema/migration/frontend change. Existing `TestResolveEstimatedKeyspaceOverrun` cases are unaffected — the guard's inputs did not change.

**Bug 2 is quick to check:** POST with `preset_job_ids: ["not-a-uuid"]` → expect a 400 naming the bad ID, not a 500. Mixed valid + invalid → 201 with the invalid one in `failures`.

**Bug 1 is awkward to trigger**, and worth stating plainly: it needs a preset with *no* cached keyspace whose pre-flight then times out, but `EnsurePresetKeyspaceFresh` normally populates that cache. To reproduce:

1. create a preset against the largest wordlist, then `UPDATE preset_jobs SET keyspace = NULL, effective_keyspace = NULL WHERE id = '<id>'`
2. set Keyspace Calculation Timeout to 1 minute
3. clear hashcat's dictstat cache so the scan is cold — a warm cache scanned 15 GB inside the 1-minute floor last time and the degrade never triggered
4. create a job from that preset and assert `base_keyspace_estimated = true` on **both** the job and its `scheduling_units` row

That last assertion is the point: the unit flag is what re-arms the tail guard.

**Standing gap:** the degrade path has still never been observed end to end, on either job type. #84 shipped with that caveat and this PR does not close it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR restores keyspace-estimate handling for preset jobs and improves validation failure responses. It preserves estimate metadata through job execution, supports degraded preset jobs, and returns clearer client-error responses for invalid requests.

- **Backend**
  - Preserves `baseEstimated` and `preflightTimeout` through job creation and scheduling.
  - Restores estimated-keyspace notifications and overrun handling for degraded preset jobs.
  - Adds overflow protection to `estimateBaseKeyspace`.
  - Classifies malformed preset and workflow references as client errors.
  - Returns HTTP 400 when all job-creation failures are client errors.
  - Removes the obsolete tuple-based `calculateKeyspace` wrapper.
  - **API contract change:** invalid all-item requests now return HTTP 400 with an “Invalid request” prefix instead of HTTP 500.
  - No database migrations or schema changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->